### PR TITLE
fix(db): use TIMESTAMPTZ for PostgreSQL timestamp columns

### DIFF
--- a/crates/bindizr-db/src/schema.rs
+++ b/crates/bindizr-db/src/schema.rs
@@ -96,7 +96,7 @@ pub(super) fn get_postgres_table_creation_queries() -> Vec<&'static str> {
             retry INTEGER NOT NULL DEFAULT 7200,
             expire INTEGER NOT NULL DEFAULT 3600000,
             minimum_ttl INTEGER NOT NULL DEFAULT 86400,
-            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
         );
         "#,
         r#"
@@ -107,7 +107,7 @@ pub(super) fn get_postgres_table_creation_queries() -> Vec<&'static str> {
             value TEXT NOT NULL,
             ttl INTEGER,
             priority INTEGER,
-            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
             zone_id INTEGER NOT NULL,
             FOREIGN KEY (zone_id) REFERENCES zones(id) ON DELETE CASCADE
         );
@@ -123,7 +123,7 @@ pub(super) fn get_postgres_table_creation_queries() -> Vec<&'static str> {
             record_value TEXT NOT NULL,
             record_ttl INTEGER,
             record_priority INTEGER,
-            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (zone_id) REFERENCES zones(id) ON DELETE CASCADE
         );
         "#,
@@ -142,7 +142,7 @@ pub(super) fn get_postgres_table_creation_queries() -> Vec<&'static str> {
             retry INTEGER NOT NULL,
             expire INTEGER NOT NULL,
             minimum_ttl INTEGER NOT NULL,
-            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
             UNIQUE(zone_id, serial),
             FOREIGN KEY (zone_id) REFERENCES zones(id) ON DELETE CASCADE
         );
@@ -152,9 +152,9 @@ pub(super) fn get_postgres_table_creation_queries() -> Vec<&'static str> {
             id SERIAL PRIMARY KEY,
             token VARCHAR(64) UNIQUE NOT NULL,
             description VARCHAR(255),
-            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            expires_at TIMESTAMP,
-            last_used_at TIMESTAMP
+            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            expires_at TIMESTAMPTZ,
+            last_used_at TIMESTAMPTZ
         );
         "#,
         r#"
@@ -162,7 +162,7 @@ pub(super) fn get_postgres_table_creation_queries() -> Vec<&'static str> {
             name VARCHAR(255) PRIMARY KEY,
             signature VARCHAR(64) NOT NULL,
             serial INTEGER NOT NULL,
-            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
         );
         "#,
     ]


### PR DESCRIPTION
The models decode timestamp fields as chrono::DateTime<Utc>, which sqlx maps to PostgreSQL's TIMESTAMPTZ, but the PostgreSQL schema declared these columns as TIMESTAMP (without time zone). Decoding then failed with:

    mismatched types; Rust type `DateTime<Utc>` (as SQL type `TIMESTAMPTZ`)
    is not compatible with SQL type `TIMESTAMP`

This broke catalog state / SOA snapshot writes (and any timestamp-returning query) on the PostgreSQL backend, e.g. zone creation returned "Failed to save SOA snapshot".

Change all PostgreSQL timestamp columns (zones, records, zone_changes, zone_soa_history, api_tokens, catalog_zone_state) to TIMESTAMPTZ to match the model types. SQLite (DATETIME) and MySQL (DATETIME) are unchanged.

Note: tables use CREATE TABLE IF NOT EXISTS, so existing PostgreSQL databases need a manual migration (ALTER TABLE ... ALTER COLUMN ... TYPE TIMESTAMPTZ); fresh databases pick up the fix automatically.