### PR TITLE
refactor: trim single-caller helpers, dead code, and restating comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,16 +217,13 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 name = "bindizr"
 version = "0.1.0-beta.7"
 dependencies = [
- "async-trait",
  "axum",
- "base64 0.23.0",
  "bindizr-core",
  "bindizr-db",
  "bindizr-service",
  "chrono",
  "clap",
  "log",
- "rand",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/bindizr-core/src/config/mod.rs
+++ b/crates/bindizr-core/src/config/mod.rs
@@ -7,7 +7,6 @@ use config::{Config, File, FileFormat};
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 
-/// Default path to the bindizr configuration file.
 pub(crate) const BINDIZR_CONF_PATH: &str = "/etc/bindizr/bindizr.conf.toml";
 
 static BINDIZR_CONFIG: OnceCell<BindizrConfig> = OnceCell::new();
@@ -283,7 +282,7 @@ pub fn load_config_file(conf_file_path: &str) -> Result<BindizrConfig, String> {
     }
 
     let cfg = load_raw_config(conf_file_path)?;
-    parse_bindizr_config(cfg)
+    parse_bindizr_config_with_env(cfg, |name| env::var(name).ok())
 }
 
 fn load_raw_config(conf_file_path: &str) -> Result<Config, String> {
@@ -296,10 +295,6 @@ fn load_raw_config(conf_file_path: &str) -> Result<Config, String> {
                 conf_file_path, e
             )
         })
-}
-
-fn parse_bindizr_config(cfg: Config) -> Result<BindizrConfig, String> {
-    parse_bindizr_config_with_env(cfg, |name| env::var(name).ok())
 }
 
 fn parse_bindizr_config_with_env(

--- a/crates/bindizr-core/src/config/tests.rs
+++ b/crates/bindizr-core/src/config/tests.rs
@@ -10,8 +10,6 @@ use crate::config::{
 struct TestConfigToml {
     api_listen_addr: &'static str,
     require_authentication: bool,
-    /// Renders `external_dns_enabled` in `[api]` when set; `None` omits it.
-    api_external_dns_enabled: Option<bool>,
     database_type: &'static str,
     /// Include the `[database.mysql]` / `[database.postgresql]` sections.
     unselected_databases: bool,
@@ -25,7 +23,6 @@ impl Default for TestConfigToml {
         Self {
             api_listen_addr: "127.0.0.1",
             require_authentication: false,
-            api_external_dns_enabled: None,
             database_type: "sqlite",
             unselected_databases: true,
             secondary_addrs: "",
@@ -41,17 +38,13 @@ impl TestConfigToml {
         } else {
             ""
         };
-        let api_external_dns = self
-            .api_external_dns_enabled
-            .map(|value| format!("external_dns_enabled = {}\n", value))
-            .unwrap_or_default();
         format!(
             r#"
 [api]
 listen_addr = "{api_listen_addr}"
 listen_port = 3000
 require_authentication = {require_authentication}
-{api_external_dns}
+
 [database]
 type = "{database_type}"
 
@@ -68,7 +61,6 @@ log_level = "debug"
 "#,
             api_listen_addr = self.api_listen_addr,
             require_authentication = self.require_authentication,
-            api_external_dns = api_external_dns,
             database_type = self.database_type,
             secondary_addrs = self.secondary_addrs,
             dns_notify = self.dns_notify,
@@ -108,64 +100,17 @@ fn parse_bindizr_config_accepts_valid_config() {
 }
 
 #[test]
-fn parse_bindizr_config_defaults_missing_optional_dns_fields() {
+fn parse_bindizr_config_defaults_missing_optional_fields() {
     let parsed = parse_config(&TestConfigToml::default()).unwrap();
 
+    assert!(parsed.api.metrics_enabled);
+    assert!(!parsed.api.external_dns_enabled);
     assert!(parsed.dns.notify_after_update);
     assert!(!parsed.dns.notify_on_startup);
     assert_eq!(parsed.dns.notify_retries, 3);
     assert_eq!(parsed.dns.notify_timeout_secs, 5);
     assert!(!parsed.dns.nsupdate_allow_unsigned);
-}
-
-#[test]
-fn parse_bindizr_config_defaults_journal_retention() {
-    let parsed = parse_config(&TestConfigToml::default()).unwrap();
-
     assert_eq!(parsed.dns.journal_retention_days, 365);
-}
-
-#[test]
-fn apply_env_overrides_covers_journal_retention() {
-    let config = Config::builder()
-        .add_source(File::from_str(
-            &TestConfigToml::default().render(),
-            FileFormat::Toml,
-        ))
-        .build()
-        .unwrap();
-    let parsed = parse_bindizr_config_with_env(config, |name| match name {
-        "BINDIZR_JOURNAL_RETENTION_DAYS" => Some("0".to_string()),
-        _ => None,
-    })
-    .unwrap();
-
-    assert_eq!(parsed.dns.journal_retention_days, 0);
-}
-
-#[test]
-fn parse_bindizr_config_defaults_metrics_enabled_to_true() {
-    let parsed = parse_config(&TestConfigToml::default()).unwrap();
-
-    assert!(parsed.api.metrics_enabled);
-}
-
-#[test]
-fn parse_bindizr_config_defaults_external_dns_to_disabled() {
-    let parsed = parse_config(&TestConfigToml::default()).unwrap();
-
-    assert!(!parsed.api.external_dns_enabled);
-}
-
-#[test]
-fn parse_bindizr_config_accepts_external_dns_enabled() {
-    let parsed = parse_config(&TestConfigToml {
-        api_external_dns_enabled: Some(true),
-        ..Default::default()
-    })
-    .unwrap();
-
-    assert!(parsed.api.external_dns_enabled);
 }
 
 #[test]
@@ -230,6 +175,7 @@ fn apply_env_overrides_replaces_config_values_before_validation() {
         "BINDIZR_NOTIFY_ON_STARTUP" => Some("true".to_string()),
         "BINDIZR_NOTIFY_RETRIES" => Some("7".to_string()),
         "BINDIZR_NOTIFY_TIMEOUT_SECS" => Some("11".to_string()),
+        "BINDIZR_JOURNAL_RETENTION_DAYS" => Some("0".to_string()),
         "BINDIZR_LOG_LEVEL" => Some("info".to_string()),
         _ => None,
     })
@@ -259,6 +205,7 @@ fn apply_env_overrides_replaces_config_values_before_validation() {
     assert!(overridden.dns.notify_on_startup);
     assert_eq!(overridden.dns.notify_retries, 7);
     assert_eq!(overridden.dns.notify_timeout_secs, 11);
+    assert_eq!(overridden.dns.journal_retention_days, 0);
     assert!(matches!(overridden.logging.log_level, LogLevel::Info));
 }
 

--- a/crates/bindizr-core/src/dns/catalog_zone.rs
+++ b/crates/bindizr-core/src/dns/catalog_zone.rs
@@ -34,7 +34,8 @@ mod tests {
 
     #[test]
     fn zone_name_to_member_id_fits_a_label_for_the_longest_zone_name() {
-        // The old dot-to-dash spelling emitted the whole name as one label.
+        // RFC 9432, Section 4.1: the id is one label, so the longest zone
+        // name must still fit under the 63-byte label cap.
         let long = [
             "a".repeat(63),
             "b".repeat(63),
@@ -48,7 +49,7 @@ mod tests {
 
     #[test]
     fn zone_name_to_member_id_distinguishes_dot_from_dash() {
-        // RFC 9432, Section 4.1 requires unique ids; "a.b" and "a-b" collided.
+        // RFC 9432, Section 4.1 requires unique ids.
         assert_ne!(
             zone_name_to_member_id("a.b.example.com"),
             zone_name_to_member_id("a-b.example.com")

--- a/crates/bindizr-core/src/dns/dnssec/signed_view/mod.rs
+++ b/crates/bindizr-core/src/dns/dnssec/signed_view/mod.rs
@@ -93,7 +93,6 @@ impl SignedViewParams<'_> {
             - chrono::Duration::seconds((slot % self.expiration_jitter_secs as u64) as i64)
     }
 
-    /// Compute the signed view these params describe.
     pub fn compute(&self) -> Result<SignedViewDiff, String> {
         let zone = self.zone;
         let apex = to_wire_name(zone.name.to_wire())?;

--- a/crates/bindizr-core/src/dns/message/mod.rs
+++ b/crates/bindizr-core/src/dns/message/mod.rs
@@ -151,12 +151,9 @@ impl DnsMessageBuilder {
         value: &str,
         priority: Option<i32>,
     ) -> Result<(), String> {
-        match EncodedRdata::from_columns(record_type, value, priority) {
-            Ok(EncodedRdata { record_type, rdata }) => {
-                self.add_raw_rdata(parse_name(name)?, record_type, ttl, rdata)
-            }
-            Err(e) => Err(e),
-        }
+        let EncodedRdata { record_type, rdata } =
+            EncodedRdata::from_columns(record_type, value, priority)?;
+        self.add_raw_rdata(parse_name(name)?, record_type, ttl, rdata)
     }
 
     /// Adds the catalog-zone NS record, which is the placeholder "invalid".
@@ -184,7 +181,6 @@ impl DnsMessageBuilder {
         )
     }
 
-    /// Adds a catalog-zone member PTR record.
     pub fn add_catalog_ptr(&mut self, zone: &Zone, member_zone: &str) -> Result<(), String> {
         let member_id = crate::dns::zone_name_to_member_id(member_zone);
         let ptr_name = format!("{}.zones.{}.", member_id, zone.name);
@@ -198,7 +194,6 @@ impl DnsMessageBuilder {
         )
     }
 
-    /// Adds an answer from a database Record model.
     pub fn add_record(&mut self, record: &Record, zone_name: &ZoneName) -> Result<(), String> {
         self.add_record_parts(
             zone_name,
@@ -376,7 +371,6 @@ impl DnsMessageBuilder {
         Ok(frame)
     }
 
-    /// Consumes the builder and returns the serialized DNS message.
     pub fn build(self) -> Vec<u8> {
         let mut message = Vec::with_capacity(self.message_len());
         self.build_message_into(&mut message);

--- a/crates/bindizr-core/src/dns/name/mod.rs
+++ b/crates/bindizr-core/src/dns/name/mod.rs
@@ -18,7 +18,6 @@ pub const MAX_DNS_LABEL_LEN: usize = 63;
 /// Maximum length of a domain name, in bytes (RFC 1035).
 pub const MAX_DOMAIN_LEN: usize = 253;
 
-/// Whether the value contains any whitespace or ASCII control character.
 pub fn has_whitespace_or_control(value: &str) -> bool {
     value
         .chars()

--- a/crates/bindizr-core/src/dns/name/zone_name.rs
+++ b/crates/bindizr-core/src/dns/name/zone_name.rs
@@ -53,7 +53,6 @@ impl ZoneName {
         to_fqdn(&self.0)
     }
 
-    /// The wire form.
     pub fn to_wire(&self) -> Result<Vec<u8>, ParseNameError> {
         super::labels_to_wire(self.0.split('.'))
     }

--- a/crates/bindizr-core/src/dns/record/soa/mod.rs
+++ b/crates/bindizr-core/src/dns/record/soa/mod.rs
@@ -18,7 +18,6 @@ pub struct SoaRecordValue<'a> {
 }
 
 impl<'a> SoaRecordValue<'a> {
-    /// The wire-format RDATA of this SOA value.
     pub fn to_rdata(&self) -> Result<Rdata, String> {
         let mut rdata = encode_name(self.mname)?;
         rdata.extend_from_slice(&encode_name(self.rname)?);

--- a/crates/bindizr-core/src/dns/record/txt/mod.rs
+++ b/crates/bindizr-core/src/dns/record/txt/mod.rs
@@ -148,7 +148,6 @@ impl TxtRecordValue {
         out
     }
 
-    /// The raw RDATA bytes.
     pub fn into_rdata(self) -> Vec<u8> {
         self.0
     }

--- a/crates/bindizr-core/src/model/dnssec_key.rs
+++ b/crates/bindizr-core/src/model/dnssec_key.rs
@@ -65,7 +65,7 @@ impl DnssecAlgorithm {
         }
     }
 
-    /// All supported algorithm names, for error messages and CLI help.
+    /// All supported algorithm names, for error messages.
     pub fn supported_names() -> &'static [&'static str] {
         &[
             "rsasha256",

--- a/crates/bindizr-core/src/model/record/mod.rs
+++ b/crates/bindizr-core/src/model/record/mod.rs
@@ -46,7 +46,6 @@ pub struct RecordWithZone {
 }
 
 impl RecordWithZone {
-    /// Create a [`RecordWithZone`] from a [`Record`] and its zone name.
     pub fn new(record: Record, zone_name: ZoneName) -> Self {
         Self {
             id: record.id,

--- a/crates/bindizr-core/src/model/tsig_key.rs
+++ b/crates/bindizr-core/src/model/tsig_key.rs
@@ -20,7 +20,7 @@ impl TsigAlgorithm {
         }
     }
 
-    /// All supported algorithm names, for error messages and CLI help.
+    /// All supported algorithm names, for error messages.
     pub fn supported_names() -> &'static [&'static str] {
         &["hmac-sha256", "hmac-sha384", "hmac-sha512"]
     }

--- a/crates/bindizr-db/src/error.rs
+++ b/crates/bindizr-db/src/error.rs
@@ -1,6 +1,5 @@
 use thiserror::Error;
 
-/// Errors returned by database operations.
 #[derive(Debug, Error)]
 pub enum DatabaseError {
     #[error("Query failed: {0}")]

--- a/crates/bindizr-db/src/lib.rs
+++ b/crates/bindizr-db/src/lib.rs
@@ -20,7 +20,6 @@ use error::DatabaseError;
 static DATABASE_POOL: OnceLock<DatabasePool> = OnceLock::new();
 static INITIALIZE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
-/// A connection pool for one of the supported database backends.
 #[derive(Debug)]
 pub(crate) enum DatabasePool {
     MySQL(Pool<MySql>),
@@ -28,7 +27,6 @@ pub(crate) enum DatabasePool {
     SQLite(Pool<Sqlite>),
 }
 
-/// Supported database backend types.
 #[derive(Debug, Clone)]
 pub(crate) enum DatabaseType {
     MySQL,

--- a/crates/bindizr-db/src/repository/mod.rs
+++ b/crates/bindizr-db/src/repository/mod.rs
@@ -42,7 +42,6 @@ pub enum LockLevel {
     None,
 }
 
-/// Optional criteria for querying zones.
 #[derive(Clone, Debug, Default)]
 pub struct ZoneFilter {
     pub name: Option<String>,
@@ -62,7 +61,6 @@ pub struct ZoneFilter {
     pub offset: Option<u64>,
 }
 
-/// Optional criteria for querying records.
 #[derive(Clone, Debug, Default)]
 pub struct RecordFilter {
     /// Matched through a subquery on `zones.name`, so the filter still lands
@@ -87,8 +85,8 @@ pub struct RecordFilter {
     pub offset: Option<u64>,
 }
 
-/// Optional criteria for querying derived DNSSEC records. Value, search, and
-/// priority have no derived-plane meaning, so the filter has no slot for them.
+/// Value, search, and priority have no derived-plane meaning, so the derived
+/// filter has no slot for them.
 #[derive(Clone, Debug, Default)]
 pub struct DnssecRecordFilter {
     /// Matched as in `RecordFilter`.
@@ -116,7 +114,6 @@ enum RepositoryTxKind<'a> {
     SQLite(sqlx::Transaction<'a, Sqlite>),
 }
 
-/// Begin a transaction on the global database pool.
 pub async fn begin_transaction() -> Result<RepositoryTx<'static>, DatabaseError> {
     // IMMEDIATE takes SQLite's write lock up front so a read-then-write
     // transaction can't fail late with "database is locked".
@@ -151,7 +148,6 @@ async fn begin(sqlite_begin: &'static str) -> Result<RepositoryTx<'static>, Data
 }
 
 impl<'a> RepositoryTx<'a> {
-    /// Commit the transaction.
     pub async fn commit(self) -> Result<(), DatabaseError> {
         match self.0 {
             RepositoryTxKind::MySQL(tx) => tx
@@ -169,7 +165,6 @@ impl<'a> RepositoryTx<'a> {
         }
     }
 
-    /// Roll back the transaction.
     pub async fn rollback(self) -> Result<(), DatabaseError> {
         match self.0 {
             RepositoryTxKind::MySQL(tx) => tx
@@ -225,7 +220,6 @@ impl<'a> RepositoryTx<'a> {
     }
 }
 
-/// Persistence operations for zones.
 #[async_trait]
 pub trait ZoneRepository: Send + Sync {
     async fn create_tx(&self, tx: &mut RepositoryTx<'_>, zone: Zone)
@@ -278,7 +272,6 @@ pub trait ZoneRepository: Send + Sync {
     async fn delete_tx(&self, tx: &mut RepositoryTx<'_>, id: i32) -> Result<(), DatabaseError>;
 }
 
-/// Persistence operations for DNSSEC policies.
 #[async_trait]
 pub trait DnssecPolicyRepository: Send + Sync {
     async fn create(&self, policy: DnssecPolicy) -> Result<DnssecPolicy, DatabaseError>;
@@ -306,7 +299,6 @@ pub trait DnssecPolicyRepository: Send + Sync {
     async fn delete(&self, id: i32) -> Result<(), DatabaseError>;
 }
 
-/// Persistence operations for TSIG keys.
 #[async_trait]
 pub trait TsigKeyRepository: Send + Sync {
     async fn create(&self, key: TsigKey) -> Result<TsigKey, DatabaseError>;
@@ -315,7 +307,6 @@ pub trait TsigKeyRepository: Send + Sync {
     async fn delete(&self, id: i32) -> Result<(), DatabaseError>;
 }
 
-/// Persistence operations for zone TSIG policies.
 #[async_trait]
 pub trait ZoneTsigPolicyRepository: Send + Sync {
     async fn create(&self, policy: ZoneTsigPolicy) -> Result<ZoneTsigPolicy, DatabaseError>;
@@ -359,7 +350,6 @@ pub trait ZoneTokenPolicyRepository: Send + Sync {
     async fn delete(&self, id: i32) -> Result<(), DatabaseError>;
 }
 
-/// Persistence operations for records.
 #[async_trait]
 pub trait RecordRepository: Send + Sync {
     async fn create_tx(
@@ -434,7 +424,6 @@ pub trait RecordRepository: Send + Sync {
     ) -> Result<(), DatabaseError>;
 }
 
-/// Persistence operations for zone changes.
 #[async_trait]
 pub trait ZoneChangeRepository: Send + Sync {
     /// Insert many zone changes in one statement (chunked). Ids are not returned.
@@ -471,7 +460,6 @@ pub trait ZoneChangeRepository: Send + Sync {
     ) -> Result<u64, DatabaseError>;
 }
 
-/// Persistence operations for zone versions.
 #[async_trait]
 pub trait ZoneVersionRepository: Send + Sync {
     async fn upsert_tx(
@@ -521,7 +509,6 @@ pub trait ZoneVersionRepository: Send + Sync {
     ) -> Result<u64, DatabaseError>;
 }
 
-/// Persistence operations for DNSSEC signing keys.
 #[async_trait]
 pub trait DnssecKeyRepository: Send + Sync {
     async fn create_tx(
@@ -535,8 +522,8 @@ pub trait DnssecKeyRepository: Send + Sync {
         zone_id: i32,
         lock_level: LockLevel,
     ) -> Result<Vec<DnssecKey>, DatabaseError>;
-    /// Keys sitting in `state` since before `cutoff`: the rollover work list.
-    /// Keys in `state` whose stamped transition deadline has passed.
+    /// Keys in `state` whose stamped `eligible_at` deadline has passed `cutoff`:
+    /// the rollover work list.
     async fn list_by_state_eligible_before(
         &self,
         state: DnssecKeyState,
@@ -621,7 +608,6 @@ pub trait DnssecRecordRepository: Send + Sync {
     async fn count_by_filter(&self, filter: DnssecRecordFilter) -> Result<u64, DatabaseError>;
 }
 
-/// Persistence operations for API tokens.
 #[async_trait]
 pub trait ApiTokenRepository: Send + Sync {
     async fn create(&self, token: ApiToken) -> Result<ApiToken, DatabaseError>;
@@ -651,7 +637,6 @@ pub trait DnssecWithdrawalRepository: Send + Sync {
     -> Result<(), DatabaseError>;
 }
 
-/// Persistence operations for catalog zone state.
 #[async_trait]
 pub trait CatalogZoneStateRepository: Send + Sync {
     /// The serial advances only when `digest` changed; returns the serial in
@@ -665,7 +650,6 @@ pub trait CatalogZoneStateRepository: Send + Sync {
     ) -> Result<i32, DatabaseError>;
 }
 
-/// Builds backend-specific repository implementations for a given pool.
 pub(crate) struct RepositoryFactory;
 
 impl RepositoryFactory {

--- a/crates/bindizr-db/src/repository/mysql/api_token_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/mysql/api_token_repository_impl.rs
@@ -3,7 +3,6 @@ use sqlx::{MySql, Pool};
 
 use crate::{error::DatabaseError, model::api_token::ApiToken, repository::ApiTokenRepository};
 
-/// MySQL-backed implementation of `ApiTokenRepository`.
 pub(crate) struct MySqlApiTokenRepository {
     pool: Pool<MySql>,
 }

--- a/crates/bindizr-db/src/repository/mysql/catalog_zone_state_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/mysql/catalog_zone_state_repository_impl.rs
@@ -5,7 +5,6 @@ use crate::{
     repository::{CatalogZoneStateRepository, RepositoryTx},
 };
 
-/// Mysql-backed implementation of `CatalogZoneStateRepository`.
 /// Every method runs on the caller's transaction, so no pool is held.
 pub(crate) struct MySqlCatalogZoneStateRepository;
 

--- a/crates/bindizr-db/src/repository/mysql/dnssec_key_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/mysql/dnssec_key_repository_impl.rs
@@ -8,7 +8,6 @@ use crate::{
     repository::{DnssecKeyRepository, LockLevel, RepositoryTx, sql::lock_clause},
 };
 
-/// MySQL-backed implementation of `DnssecKeyRepository`.
 pub(crate) struct MySqlDnssecKeyRepository {
     pool: Pool<MySql>,
 }

--- a/crates/bindizr-db/src/repository/mysql/dnssec_policy_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/mysql/dnssec_policy_repository_impl.rs
@@ -7,7 +7,6 @@ use crate::{
     repository::{DnssecPolicyRepository, LockLevel, RepositoryTx, sql::lock_clause},
 };
 
-/// MySql-backed implementation of `DnssecPolicyRepository`.
 pub(crate) struct MySqlDnssecPolicyRepository {
     pool: Pool<MySql>,
 }

--- a/crates/bindizr-db/src/repository/mysql/dnssec_record_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/mysql/dnssec_record_repository_impl.rs
@@ -11,7 +11,6 @@ use crate::{
     },
 };
 
-/// MySQL-backed implementation of `DnssecRecordRepository`.
 pub(crate) struct MySqlDnssecRecordRepository {
     pool: Pool<MySql>,
 }

--- a/crates/bindizr-db/src/repository/mysql/dnssec_withdrawal_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/mysql/dnssec_withdrawal_repository_impl.rs
@@ -5,7 +5,6 @@ use crate::{
     repository::{DnssecWithdrawalRepository, RepositoryTx},
 };
 
-/// MySQL-backed implementation of `DnssecWithdrawalRepository`.
 /// Every method runs on the caller's transaction, so no pool is held.
 pub(crate) struct MySqlDnssecWithdrawalRepository;
 

--- a/crates/bindizr-db/src/repository/mysql/record_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/mysql/record_repository_impl.rs
@@ -13,7 +13,6 @@ use crate::{
     },
 };
 
-/// MySQL-backed implementation of `RecordRepository`.
 pub(crate) struct MySqlRecordRepository {
     pool: Pool<MySql>,
 }

--- a/crates/bindizr-db/src/repository/mysql/tsig_key_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/mysql/tsig_key_repository_impl.rs
@@ -3,7 +3,6 @@ use sqlx::{MySql, Pool};
 
 use crate::{error::DatabaseError, model::tsig_key::TsigKey, repository::TsigKeyRepository};
 
-/// MySQL-backed implementation of `TsigKeyRepository`.
 pub(crate) struct MySqlTsigKeyRepository {
     pool: Pool<MySql>,
 }

--- a/crates/bindizr-db/src/repository/mysql/zone_change_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/mysql/zone_change_repository_impl.rs
@@ -7,7 +7,6 @@ use crate::{
     repository::{LockLevel, RepositoryTx, ZoneChangeRepository, sql::lock_clause},
 };
 
-/// MySQL-backed implementation of `ZoneChangeRepository`.
 pub(crate) struct MySqlZoneChangeRepository {
     pool: Pool<MySql>,
 }

--- a/crates/bindizr-db/src/repository/mysql/zone_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/mysql/zone_repository_impl.rs
@@ -10,7 +10,6 @@ use crate::{
     },
 };
 
-/// MySQL-backed implementation of `ZoneRepository`.
 pub(crate) struct MySqlZoneRepository {
     pool: Pool<MySql>,
 }

--- a/crates/bindizr-db/src/repository/mysql/zone_token_policy_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/mysql/zone_token_policy_repository_impl.rs
@@ -7,7 +7,6 @@ use crate::{
     repository::{LockLevel, RepositoryTx, ZoneTokenPolicyRepository, sql::lock_clause},
 };
 
-/// MySQL-backed implementation of `ZoneTokenPolicyRepository`.
 pub(crate) struct MySqlZoneTokenPolicyRepository {
     pool: Pool<MySql>,
 }

--- a/crates/bindizr-db/src/repository/mysql/zone_tsig_policy_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/mysql/zone_tsig_policy_repository_impl.rs
@@ -7,7 +7,6 @@ use crate::{
     repository::{LockLevel, RepositoryTx, ZoneTsigPolicyRepository, sql::lock_clause},
 };
 
-/// MySQL-backed implementation of `ZoneTsigPolicyRepository`.
 pub(crate) struct MySqlZoneTsigPolicyRepository {
     pool: Pool<MySql>,
 }

--- a/crates/bindizr-db/src/repository/mysql/zone_version_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/mysql/zone_version_repository_impl.rs
@@ -29,7 +29,6 @@ const USER_CHANGES_FILTER: &str = r#"
                   )
               )"#;
 
-/// MySQL-backed implementation of `ZoneVersionRepository`.
 pub(crate) struct MySqlZoneVersionRepository {
     pool: Pool<MySql>,
 }

--- a/crates/bindizr-db/src/repository/postgres/api_token_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/postgres/api_token_repository_impl.rs
@@ -3,7 +3,6 @@ use sqlx::{Pool, Postgres, Row};
 
 use crate::{error::DatabaseError, model::api_token::ApiToken, repository::ApiTokenRepository};
 
-/// PostgreSQL-backed implementation of `ApiTokenRepository`.
 pub(crate) struct PostgresApiTokenRepository {
     pool: Pool<Postgres>,
 }

--- a/crates/bindizr-db/src/repository/postgres/catalog_zone_state_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/postgres/catalog_zone_state_repository_impl.rs
@@ -5,7 +5,6 @@ use crate::{
     repository::{CatalogZoneStateRepository, RepositoryTx},
 };
 
-/// Postgres-backed implementation of `CatalogZoneStateRepository`.
 /// Every method runs on the caller's transaction, so no pool is held.
 pub(crate) struct PostgresCatalogZoneStateRepository;
 

--- a/crates/bindizr-db/src/repository/postgres/dnssec_key_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/postgres/dnssec_key_repository_impl.rs
@@ -8,7 +8,6 @@ use crate::{
     repository::{DnssecKeyRepository, LockLevel, RepositoryTx, sql::lock_clause},
 };
 
-/// PostgreSQL-backed implementation of `DnssecKeyRepository`.
 pub(crate) struct PostgresDnssecKeyRepository {
     pool: Pool<Postgres>,
 }

--- a/crates/bindizr-db/src/repository/postgres/dnssec_policy_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/postgres/dnssec_policy_repository_impl.rs
@@ -7,7 +7,6 @@ use crate::{
     repository::{DnssecPolicyRepository, LockLevel, RepositoryTx, sql::lock_clause},
 };
 
-/// Postgres-backed implementation of `DnssecPolicyRepository`.
 pub(crate) struct PostgresDnssecPolicyRepository {
     pool: Pool<Postgres>,
 }

--- a/crates/bindizr-db/src/repository/postgres/dnssec_record_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/postgres/dnssec_record_repository_impl.rs
@@ -11,7 +11,6 @@ use crate::{
     },
 };
 
-/// PostgreSQL-backed implementation of `DnssecRecordRepository`.
 pub(crate) struct PostgresDnssecRecordRepository {
     pool: Pool<Postgres>,
 }

--- a/crates/bindizr-db/src/repository/postgres/dnssec_withdrawal_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/postgres/dnssec_withdrawal_repository_impl.rs
@@ -5,7 +5,6 @@ use crate::{
     repository::{DnssecWithdrawalRepository, RepositoryTx},
 };
 
-/// PostgreSQL-backed implementation of `DnssecWithdrawalRepository`.
 /// Every method runs on the caller's transaction, so no pool is held.
 pub(crate) struct PostgresDnssecWithdrawalRepository;
 

--- a/crates/bindizr-db/src/repository/postgres/record_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/postgres/record_repository_impl.rs
@@ -13,7 +13,6 @@ use crate::{
     },
 };
 
-/// PostgreSQL-backed implementation of `RecordRepository`.
 pub(crate) struct PostgresRecordRepository {
     pool: Pool<Postgres>,
 }

--- a/crates/bindizr-db/src/repository/postgres/tsig_key_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/postgres/tsig_key_repository_impl.rs
@@ -3,7 +3,6 @@ use sqlx::{Pool, Postgres, Row};
 
 use crate::{error::DatabaseError, model::tsig_key::TsigKey, repository::TsigKeyRepository};
 
-/// PostgreSQL-backed implementation of `TsigKeyRepository`.
 pub(crate) struct PostgresTsigKeyRepository {
     pool: Pool<Postgres>,
 }

--- a/crates/bindizr-db/src/repository/postgres/zone_change_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/postgres/zone_change_repository_impl.rs
@@ -7,7 +7,6 @@ use crate::{
     repository::{LockLevel, RepositoryTx, ZoneChangeRepository, sql::lock_clause},
 };
 
-/// PostgreSQL-backed implementation of `ZoneChangeRepository`.
 pub(crate) struct PostgresZoneChangeRepository {
     pool: Pool<Postgres>,
 }

--- a/crates/bindizr-db/src/repository/postgres/zone_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/postgres/zone_repository_impl.rs
@@ -10,7 +10,6 @@ use crate::{
     },
 };
 
-/// PostgreSQL-backed implementation of `ZoneRepository`.
 pub(crate) struct PostgresZoneRepository {
     pool: Pool<Postgres>,
 }

--- a/crates/bindizr-db/src/repository/postgres/zone_token_policy_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/postgres/zone_token_policy_repository_impl.rs
@@ -7,7 +7,6 @@ use crate::{
     repository::{LockLevel, RepositoryTx, ZoneTokenPolicyRepository, sql::lock_clause},
 };
 
-/// PostgreSQL-backed implementation of `ZoneTokenPolicyRepository`.
 pub(crate) struct PostgresZoneTokenPolicyRepository {
     pool: Pool<Postgres>,
 }

--- a/crates/bindizr-db/src/repository/postgres/zone_tsig_policy_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/postgres/zone_tsig_policy_repository_impl.rs
@@ -7,7 +7,6 @@ use crate::{
     repository::{LockLevel, RepositoryTx, ZoneTsigPolicyRepository, sql::lock_clause},
 };
 
-/// PostgreSQL-backed implementation of `ZoneTsigPolicyRepository`.
 pub(crate) struct PostgresZoneTsigPolicyRepository {
     pool: Pool<Postgres>,
 }

--- a/crates/bindizr-db/src/repository/postgres/zone_version_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/postgres/zone_version_repository_impl.rs
@@ -29,7 +29,6 @@ const USER_CHANGES_FILTER: &str = r#"
                   )
               )"#;
 
-/// PostgreSQL-backed implementation of `ZoneVersionRepository`.
 pub(crate) struct PostgresZoneVersionRepository {
     pool: Pool<Postgres>,
 }

--- a/crates/bindizr-db/src/repository/sqlite/api_token_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/sqlite/api_token_repository_impl.rs
@@ -3,7 +3,6 @@ use sqlx::{Pool, Sqlite};
 
 use crate::{error::DatabaseError, model::api_token::ApiToken, repository::ApiTokenRepository};
 
-/// SQLite-backed implementation of `ApiTokenRepository`.
 pub(crate) struct SqliteApiTokenRepository {
     pool: Pool<Sqlite>,
 }

--- a/crates/bindizr-db/src/repository/sqlite/catalog_zone_state_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/sqlite/catalog_zone_state_repository_impl.rs
@@ -5,7 +5,6 @@ use crate::{
     repository::{CatalogZoneStateRepository, RepositoryTx},
 };
 
-/// Sqlite-backed implementation of `CatalogZoneStateRepository`.
 /// Every method runs on the caller's transaction, so no pool is held.
 pub(crate) struct SqliteCatalogZoneStateRepository;
 

--- a/crates/bindizr-db/src/repository/sqlite/dnssec_key_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/sqlite/dnssec_key_repository_impl.rs
@@ -8,7 +8,6 @@ use crate::{
     repository::{DnssecKeyRepository, LockLevel, RepositoryTx},
 };
 
-/// SQLite-backed implementation of `DnssecKeyRepository`.
 pub(crate) struct SqliteDnssecKeyRepository {
     pool: Pool<Sqlite>,
 }

--- a/crates/bindizr-db/src/repository/sqlite/dnssec_policy_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/sqlite/dnssec_policy_repository_impl.rs
@@ -7,7 +7,6 @@ use crate::{
     repository::{DnssecPolicyRepository, LockLevel, RepositoryTx},
 };
 
-/// Sqlite-backed implementation of `DnssecPolicyRepository`.
 pub(crate) struct SqliteDnssecPolicyRepository {
     pool: Pool<Sqlite>,
 }

--- a/crates/bindizr-db/src/repository/sqlite/dnssec_record_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/sqlite/dnssec_record_repository_impl.rs
@@ -10,7 +10,6 @@ use crate::{
     },
 };
 
-/// SQLite-backed implementation of `DnssecRecordRepository`.
 pub(crate) struct SqliteDnssecRecordRepository {
     pool: Pool<Sqlite>,
 }

--- a/crates/bindizr-db/src/repository/sqlite/dnssec_withdrawal_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/sqlite/dnssec_withdrawal_repository_impl.rs
@@ -5,7 +5,6 @@ use crate::{
     repository::{DnssecWithdrawalRepository, RepositoryTx},
 };
 
-/// Sqlite-backed implementation of `DnssecWithdrawalRepository`.
 /// Every method runs on the caller's transaction, so no pool is held.
 pub(crate) struct SqliteDnssecWithdrawalRepository;
 

--- a/crates/bindizr-db/src/repository/sqlite/record_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/sqlite/record_repository_impl.rs
@@ -11,7 +11,6 @@ use crate::{
     },
 };
 
-/// SQLite-backed implementation of `RecordRepository`.
 pub(crate) struct SqliteRecordRepository {
     pool: Pool<Sqlite>,
 }

--- a/crates/bindizr-db/src/repository/sqlite/tsig_key_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/sqlite/tsig_key_repository_impl.rs
@@ -3,7 +3,6 @@ use sqlx::{Pool, Sqlite};
 
 use crate::{error::DatabaseError, model::tsig_key::TsigKey, repository::TsigKeyRepository};
 
-/// SQLite-backed implementation of `TsigKeyRepository`.
 pub(crate) struct SqliteTsigKeyRepository {
     pool: Pool<Sqlite>,
 }

--- a/crates/bindizr-db/src/repository/sqlite/zone_change_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/sqlite/zone_change_repository_impl.rs
@@ -7,7 +7,6 @@ use crate::{
     repository::{LockLevel, RepositoryTx, ZoneChangeRepository},
 };
 
-/// SQLite-backed implementation of `ZoneChangeRepository`.
 pub(crate) struct SqliteZoneChangeRepository {
     pool: Pool<Sqlite>,
 }

--- a/crates/bindizr-db/src/repository/sqlite/zone_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/sqlite/zone_repository_impl.rs
@@ -7,7 +7,6 @@ use crate::{
     repository::{LockLevel, RepositoryTx, ZoneFilter, ZoneRepository, sql::like_pattern},
 };
 
-/// SQLite-backed implementation of `ZoneRepository`.
 pub(crate) struct SqliteZoneRepository {
     pool: Pool<Sqlite>,
 }

--- a/crates/bindizr-db/src/repository/sqlite/zone_token_policy_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/sqlite/zone_token_policy_repository_impl.rs
@@ -7,7 +7,6 @@ use crate::{
     repository::{LockLevel, RepositoryTx, ZoneTokenPolicyRepository},
 };
 
-/// SQLite-backed implementation of `ZoneTokenPolicyRepository`.
 pub(crate) struct SqliteZoneTokenPolicyRepository {
     pool: Pool<Sqlite>,
 }

--- a/crates/bindizr-db/src/repository/sqlite/zone_tsig_policy_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/sqlite/zone_tsig_policy_repository_impl.rs
@@ -7,7 +7,6 @@ use crate::{
     repository::{LockLevel, RepositoryTx, ZoneTsigPolicyRepository},
 };
 
-/// SQLite-backed implementation of `ZoneTsigPolicyRepository`.
 pub(crate) struct SqliteZoneTsigPolicyRepository {
     pool: Pool<Sqlite>,
 }

--- a/crates/bindizr-db/src/repository/sqlite/zone_version_repository_impl.rs
+++ b/crates/bindizr-db/src/repository/sqlite/zone_version_repository_impl.rs
@@ -29,7 +29,6 @@ const USER_CHANGES_FILTER: &str = r#"
                   )
               )"#;
 
-/// SQLite-backed implementation of `ZoneVersionRepository`.
 pub(crate) struct SqliteZoneVersionRepository {
     pool: Pool<Sqlite>,
 }

--- a/crates/bindizr-e2e/tests/api/tsig_key.rs
+++ b/crates/bindizr-e2e/tests/api/tsig_key.rs
@@ -3,7 +3,6 @@ use serde_json::json;
 
 use crate::common::TestApp;
 
-/// Create a zone under the given name with minimal fields.
 async fn create_named_zone(app: &TestApp, zone_name: &str) {
     let (status, _) = app
         .request(

--- a/crates/bindizr-e2e/tests/common/mod.rs
+++ b/crates/bindizr-e2e/tests/common/mod.rs
@@ -64,26 +64,22 @@ enum TestRuntime {
 
 impl TestApp {
     pub(crate) async fn start() -> Self {
-        if dns_verification_enabled() {
+        if env_flag(DNS_VERIFICATION_ENV) {
             Self::start_compose().await
         } else {
-            Self::start_local_with(TestAppOptions::default()).await
+            Self::start_with_options(TestAppOptions::default()).await
         }
     }
 
     /// A locally spawned daemon with the default config, even in compose
     /// mode — for tests bound to this host's filesystem or default config.
     pub(crate) async fn start_local() -> Self {
-        Self::start_local_with(TestAppOptions::default()).await
+        Self::start_with_options(TestAppOptions::default()).await
     }
 
     /// Start with non-default config; always the local runtime, because the
     /// compose stack's config is fixed.
     pub(crate) async fn start_with_options(options: TestAppOptions) -> Self {
-        Self::start_local_with(options).await
-    }
-
-    async fn start_local_with(options: TestAppOptions) -> Self {
         let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
         let db_path = temp_dir.path().join("bindizr.sqlite");
         fs::File::create(&db_path).expect("failed to create sqlite file");
@@ -272,7 +268,6 @@ impl TestApp {
         (status, body)
     }
 
-    /// A zone's records as the API reports them.
     pub(crate) async fn list_records(&self, zone_name: &str) -> Vec<Value> {
         let (status, body) = self
             .request(
@@ -288,7 +283,6 @@ impl TestApp {
             .clone()
     }
 
-    /// A zone's current SOA serial.
     pub(crate) async fn zone_serial(&self, zone_name: &str) -> i64 {
         let (status, body) = self
             .request(Method::GET, &format!("/zones/{zone_name}"), None)
@@ -602,10 +596,6 @@ fn test_namespace() -> String {
     });
     let sequence = TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     format!("{run_id}-{sequence}")
-}
-
-fn dns_verification_enabled() -> bool {
-    env_flag(DNS_VERIFICATION_ENV)
 }
 
 /// The ARM override swaps the amd64-only ISC bind9 image for a multi-arch one.

--- a/crates/bindizr-e2e/tests/dns/nsupdate.rs
+++ b/crates/bindizr-e2e/tests/dns/nsupdate.rs
@@ -246,12 +246,6 @@ async fn nsupdate_advances_the_zone_serial_once_per_message() {
     assert_eq!(app.zone_serial(&zone_name).await, before + 1);
 }
 
-/// A signed update carries a key, so the zone's TSIG policies decide what it
-/// may touch — the leg the unsigned tests above skip entirely.
-async fn signed_nsupdate_app() -> TestApp {
-    TestApp::start_local().await
-}
-
 async fn create_key(app: &TestApp, name: &str) -> SigningKey {
     app.run_cli_success(&["tsig-key", "create", "--name", name])
         .await;
@@ -268,10 +262,12 @@ async fn create_key(app: &TestApp, name: &str) -> SigningKey {
     }
 }
 
+// A signed update carries a key, so the zone's TSIG policies decide what it
+// may touch — the leg the unsigned tests above skip entirely.
 #[tokio::test]
 #[serial]
 async fn signed_nsupdate_needs_a_policy_for_the_zone() {
-    let app = signed_nsupdate_app().await;
+    let app = TestApp::start_local().await;
     let zone_name = app.zone_name("nsupdate-policy.example");
     app.create_zone_cli(&zone_name, "3600").await;
     let port = app.dns_port();

--- a/crates/bindizr-external-dns/src/config.rs
+++ b/crates/bindizr-external-dns/src/config.rs
@@ -54,7 +54,6 @@ pub(crate) struct Cli {
     pub(crate) log_level: String,
 }
 
-/// Resolved adapter configuration.
 #[derive(Debug)]
 pub(crate) struct AdapterConfig {
     /// Normalized base URL without a trailing slash.

--- a/crates/bindizr-external-dns/src/wire/mod.rs
+++ b/crates/bindizr-external-dns/src/wire/mod.rs
@@ -47,7 +47,7 @@ pub(crate) struct ProviderSpecificProperty {
 }
 
 /// JSON shape of external-dns `plan.Changes` (`POST /records` body).
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Changes {
     #[serde(default)]
@@ -61,7 +61,7 @@ pub(crate) struct Changes {
 }
 
 /// JSON shape of external-dns `endpoint.DomainFilter` (negotiation response).
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, Serialize)]
 pub(crate) struct DomainFilter {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) include: Vec<String>,
@@ -78,7 +78,7 @@ pub(crate) struct BindizrRrset {
 }
 
 /// `POST /external-dns/changes` request body of the bindizr API.
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, Serialize)]
 pub(crate) struct BindizrChanges {
     pub(crate) creates: Vec<BindizrRrset>,
     pub(crate) updates: Vec<BindizrRrsetUpdate>,
@@ -235,8 +235,7 @@ pub(crate) fn group_records_into_endpoints(records: Vec<BindizrRecordItem>) -> V
         .collect()
 }
 
-/// Validate desired endpoints and convert them for `POST /adjust`;
-/// validation is mirrored here so a bad plan fails without a round trip.
+/// Validate desired endpoints and convert them for `POST /adjust`.
 pub(crate) fn to_bindizr_rrsets(endpoints: &[Endpoint]) -> Result<Vec<BindizrRrset>, String> {
     for endpoint in endpoints {
         endpoint.validate()?;

--- a/crates/bindizr-external-dns/src/wire/tests.rs
+++ b/crates/bindizr-external-dns/src/wire/tests.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 
-use super::{BindizrRecordItem, Changes, DomainFilter, Endpoint, group_records_into_endpoints};
+use super::{Changes, Endpoint};
 
 fn endpoint(dns_name: &str, record_type: &str, ttl: i64, targets: &[&str]) -> Endpoint {
     Endpoint {
@@ -55,40 +55,6 @@ fn endpoint_serializes_with_omitempty_semantics() {
     let serialized =
         serde_json::to_value(endpoint("app.example.com", "A", 0, &["192.0.2.10"])).unwrap();
     assert!(serialized.get("recordTTL").is_none());
-}
-
-#[test]
-fn changes_deserializes_plan_wire_format() {
-    let parsed: Changes = serde_json::from_value(json!({
-        "create": [{"dnsName": "a.example.com", "targets": ["192.0.2.1"], "recordType": "A"}],
-        "updateOld": [{"dnsName": "b.example.com", "targets": ["192.0.2.2"], "recordType": "A"}],
-        "updateNew": [{"dnsName": "b.example.com", "targets": ["192.0.2.3"], "recordType": "A"}],
-        "delete": [{"dnsName": "c.example.com", "targets": ["192.0.2.4"], "recordType": "A"}]
-    }))
-    .unwrap();
-
-    assert_eq!(parsed.create.len(), 1);
-    assert_eq!(parsed.update_old.len(), 1);
-    assert_eq!(parsed.update_new.len(), 1);
-    assert_eq!(parsed.delete.len(), 1);
-
-    let empty: Changes = serde_json::from_value(json!({})).unwrap();
-    assert!(empty.create.is_empty());
-}
-
-#[test]
-fn domain_filter_serializes_include_list() {
-    let filter = DomainFilter {
-        include: vec!["example.com".to_string()],
-    };
-    assert_eq!(
-        serde_json::to_value(&filter).unwrap(),
-        json!({"include": ["example.com"]})
-    );
-    assert_eq!(
-        serde_json::to_value(DomainFilter::default()).unwrap(),
-        json!({})
-    );
 }
 
 #[test]
@@ -169,40 +135,4 @@ fn changes_to_bindizr_rejects_mismatched_update_pairs() {
     .unwrap();
 
     assert!(changes.to_bindizr().is_err());
-}
-
-#[test]
-fn group_records_builds_one_endpoint_per_rrset() {
-    let records = vec![
-        BindizrRecordItem {
-            name: "app.example.com".to_string(),
-            record_type: "A".to_string(),
-            ttl: 300,
-            value: "192.0.2.2".to_string(),
-        },
-        BindizrRecordItem {
-            name: "app.example.com".to_string(),
-            record_type: "A".to_string(),
-            ttl: 300,
-            value: "192.0.2.1".to_string(),
-        },
-        BindizrRecordItem {
-            name: "app.example.com".to_string(),
-            record_type: "TXT".to_string(),
-            ttl: 3600,
-            value: "\"heritage=external-dns,external-dns/owner=default\"".to_string(),
-        },
-    ];
-
-    let endpoints = group_records_into_endpoints(records);
-
-    assert_eq!(endpoints.len(), 2);
-    assert_eq!(endpoints[0].record_type, "A");
-    assert_eq!(endpoints[0].targets, vec!["192.0.2.1", "192.0.2.2"]);
-    assert_eq!(endpoints[0].record_ttl, 300);
-    assert_eq!(endpoints[1].record_type, "TXT");
-    assert_eq!(
-        endpoints[1].targets,
-        vec!["\"heritage=external-dns,external-dns/owner=default\""]
-    );
 }

--- a/crates/bindizr-service/src/dnssec/status.rs
+++ b/crates/bindizr-service/src/dnssec/status.rs
@@ -86,21 +86,11 @@ pub(crate) async fn build_status_tx(
     keys: &[DnssecKey],
     serial: i32,
 ) -> Result<GetDnssecStatusResponse, ServiceError> {
-    let earliest = DnssecService::earliest_expiry_tx(tx, zone.id).await?;
+    let earliest_signature_expires_at = DnssecService::earliest_expiry_tx(tx, zone.id).await?;
     let withdrawing = RepositoryService::get_dnssec_withdrawal_tx(tx, zone.id)
         .await?
         .is_some();
-    build_status(zone, policy, keys, earliest, serial, withdrawing)
-}
 
-fn build_status(
-    zone: &Zone,
-    policy: Option<&DnssecPolicy>,
-    keys: &[DnssecKey],
-    earliest_signature_expires_at: Option<DateTime<Utc>>,
-    serial: i32,
-    withdrawing: bool,
-) -> Result<GetDnssecStatusResponse, ServiceError> {
     // The parent needs DS records only for the SEP keys the zone still wants
     // delegated trust for.
     let ds_records = keys

--- a/crates/bindizr-service/src/dynamic_update/mod.rs
+++ b/crates/bindizr-service/src/dynamic_update/mod.rs
@@ -265,17 +265,57 @@ async fn apply_op(
             ttl,
             priority,
         } => {
-            add_record(
+            let owner = owner_in_zone(name, &zone.name)?;
+
+            // Row-encode so nsupdate stores the same spelling as the other write
+            // paths; TXT arrives already encoded from the wire rdata.
+            let value = if *record_type == RecordType::TXT {
+                value.to_string()
+            } else {
+                record_type.encoded_value(value, *priority).map_err(|e| {
+                    DynamicUpdateError::Refused(format!(
+                        "invalid {} rdata: {}",
+                        record_type.as_str(),
+                        e
+                    ))
+                })?
+            };
+
+            let outcome = RecordService::validate_add_tx(
                 tx,
                 zone,
-                name,
+                &owner,
                 record_type,
-                value,
+                &value,
                 *ttl,
                 *priority,
-                new_serial,
             )
-            .await
+            .await?;
+
+            // RFC 2136, Section 3.4.2.2: an rdata-identical add is a silent no-op. The
+            // TTL-replace clause is not implemented; RRset TTLs change via the API.
+            if matches!(outcome, AddOutcome::Duplicate) {
+                return Ok(false);
+            }
+
+            RecordService::insert_records_with_changes_tx(
+                tx,
+                zone.id,
+                new_serial,
+                &[Record {
+                    id: 0,
+                    name: owner,
+                    record_type: record_type.clone(),
+                    value,
+                    ttl: *ttl,
+                    priority: *priority,
+                    zone_id: zone.id,
+                    created_at: Utc::now(),
+                }],
+            )
+            .await?;
+
+            Ok(true)
         }
         UpdateOp::DeleteRrset { name, record_type } => {
             delete_matching(tx, zone, name, record_type.as_ref(), None, None, new_serial).await
@@ -298,59 +338,6 @@ async fn apply_op(
             .await
         }
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn add_record(
-    tx: &mut RepositoryTx<'_>,
-    zone: &Zone,
-    name: &str,
-    record_type: &RecordType,
-    value: &str,
-    ttl: i32,
-    priority: Option<i32>,
-    new_serial: i32,
-) -> Result<bool, DynamicUpdateError> {
-    let owner = owner_in_zone(name, &zone.name)?;
-
-    // Row-encode so nsupdate stores the same spelling as the other write
-    // paths; TXT arrives already encoded from the wire rdata.
-    let value = if *record_type == RecordType::TXT {
-        value.to_string()
-    } else {
-        record_type.encoded_value(value, priority).map_err(|e| {
-            DynamicUpdateError::Refused(format!("invalid {} rdata: {}", record_type.as_str(), e))
-        })?
-    };
-
-    let outcome =
-        RecordService::validate_add_tx(tx, zone, &owner, record_type, &value, ttl, priority)
-            .await?;
-
-    // RFC 2136, Section 3.4.2.2: an rdata-identical add is a silent no-op. The
-    // TTL-replace clause is not implemented; RRset TTLs change via the API.
-    if matches!(outcome, AddOutcome::Duplicate) {
-        return Ok(false);
-    }
-
-    RecordService::insert_records_with_changes_tx(
-        tx,
-        zone.id,
-        new_serial,
-        &[Record {
-            id: 0,
-            name: owner,
-            record_type: record_type.clone(),
-            value,
-            ttl,
-            priority,
-            zone_id: zone.id,
-            created_at: Utc::now(),
-        }],
-    )
-    .await?;
-
-    Ok(true)
 }
 
 /// Delete every record at `name` matching the given type and (optionally)

--- a/crates/bindizr-service/src/dynamic_update/prerequisite.rs
+++ b/crates/bindizr-service/src/dynamic_update/prerequisite.rs
@@ -11,7 +11,7 @@ use crate::{
         record::{Record, RecordType},
         zone::Zone,
     },
-    record::RecordService,
+    repository::RepositoryService,
 };
 
 pub(crate) async fn evaluate_prerequisites_tx(
@@ -23,7 +23,8 @@ pub(crate) async fn evaluate_prerequisites_tx(
         return Ok(());
     }
 
-    let zone_records = RecordService::list_tx(tx, zone.id, LockLevel::Exclusive).await?;
+    let zone_records =
+        RepositoryService::list_records_tx(tx, zone.id, LockLevel::Exclusive).await?;
 
     for prerequisite in prerequisites {
         match prerequisite {

--- a/crates/bindizr-service/src/record/get.rs
+++ b/crates/bindizr-service/src/record/get.rs
@@ -1,9 +1,8 @@
 use bindizr_core::dns::name::{OwnerName, ZoneName};
-use bindizr_db::repository::{DnssecRecordFilter, LockLevel, RecordFilter};
+use bindizr_db::repository::{DnssecRecordFilter, RecordFilter};
 
 use super::{ListedRecord, RecordService};
 use crate::{
-    RepositoryTx,
     authorization::Caller,
     error::ServiceError,
     log_error,
@@ -38,15 +37,6 @@ fn parse_type_filter(
 }
 
 impl RecordService {
-    /// List all records in a zone by zone id, within the caller's transaction.
-    pub(crate) async fn list_tx(
-        tx: &mut RepositoryTx<'_>,
-        zone_id: i32,
-        lock_level: LockLevel,
-    ) -> Result<Vec<Record>, ServiceError> {
-        RepositoryService::list_records_tx(tx, zone_id, lock_level).await
-    }
-
     /// List a zone's records for `caller`; a zone it cannot see reads as
     /// `NotFound`.
     pub async fn list_in_zone(

--- a/crates/bindizr-service/src/serial.rs
+++ b/crates/bindizr-service/src/serial.rs
@@ -63,10 +63,8 @@ mod tests {
     fn increments_by_one() {
         assert_eq!(generate_serial(Some(1)).unwrap(), 2);
         assert_eq!(generate_serial(Some(41)).unwrap(), 42);
-    }
-
-    #[test]
-    fn continues_from_explicit_legacy_serials() {
+        // A datestamp serial carried over from another primary is only a
+        // larger starting point.
         assert_eq!(generate_serial(Some(2023010101)).unwrap(), 2023010102);
     }
 

--- a/crates/bindizr-service/src/token/tests.rs
+++ b/crates/bindizr-service/src/token/tests.rs
@@ -2,15 +2,11 @@ use super::{normalize_token_name, validate_expires_in_days};
 use crate::error::ErrorCode;
 
 #[test]
-fn normalize_token_name_trims_and_accepts_plain_names() {
+fn normalize_token_name_trims_and_folds_case() {
     assert_eq!(
         normalize_token_name(" external-dns ").unwrap(),
         "external-dns"
     );
-}
-
-#[test]
-fn normalize_token_name_folds_case() {
     assert_eq!(normalize_token_name("Deploy").unwrap(), "deploy");
     assert_eq!(
         normalize_token_name("DEPLOY").unwrap(),

--- a/crates/bindizr-service/src/types/record.rs
+++ b/crates/bindizr-service/src/types/record.rs
@@ -51,14 +51,9 @@ pub(crate) fn display_record_value_request(
     value: &str,
     record_type: &RecordType,
 ) -> RecordValueRequest {
-    if *record_type == RecordType::TXT {
-        decode_txt_value_request(value)
-    } else {
-        RecordValueRequest::String(record_type.display_value(value))
+    if *record_type != RecordType::TXT {
+        return RecordValueRequest::String(record_type.display_value(value));
     }
-}
-
-fn decode_txt_value_request(value: &str) -> RecordValueRequest {
     match TxtRecordValue::from_presentation(value).and_then(|rdata| rdata.to_content()) {
         Some(TxtContent::Single(value)) => RecordValueRequest::String(value),
         Some(TxtContent::Segments(segments)) => RecordValueRequest::Segments(segments),

--- a/crates/bindizr-service/src/zone/get.rs
+++ b/crates/bindizr-service/src/zone/get.rs
@@ -19,7 +19,6 @@ impl ZoneService {
         RepositoryService::get_zone_by_name(lookup_name.as_str()).await
     }
 
-    /// Look up a zone by name within the caller's transaction.
     pub(crate) async fn find_by_name_tx(
         tx: &mut RepositoryTx<'_>,
         zone_name: &str,
@@ -43,7 +42,6 @@ impl ZoneService {
         RepositoryService::ping_zones().await
     }
 
-    /// List all zones.
     pub async fn list() -> Result<Vec<Zone>, ServiceError> {
         RepositoryService::list_zones().await.map_err(|e| {
             log_error!("Failed to fetch zones: {}", e);

--- a/crates/bindizr-service/src/zone/history.rs
+++ b/crates/bindizr-service/src/zone/history.rs
@@ -21,7 +21,6 @@ use crate::{
         record::{Record, RecordType},
         zone::Zone,
         zone_change::{ChangeOperation, JournalRecordType},
-        zone_version::ZoneVersion,
     },
     record::{
         RecordService, validate_delete_constraints, validate_record_add_constraints_normalized,
@@ -210,34 +209,6 @@ fn sort_records(records: &mut [ReconstructedRecord]) {
     });
 }
 
-/// Build the zone as it should look after rolling back to `version`: SOA
-/// metadata from the version, identity (id/name) and creation time unchanged,
-/// serial advanced to `new_serial`.
-fn restored_zone_from_version(
-    zone: &Zone,
-    version: &ZoneVersion,
-    new_serial: i32,
-) -> Result<Zone, ServiceError> {
-    let rname = SoaMailbox::from_encoded(&version.rname)
-        .to_email()
-        .map_err(|e| ServiceError::internal(format!("Failed to decode version rname: {}", e)))?;
-
-    Ok(Zone {
-        id: zone.id,
-        name: zone.name.clone(),
-        mname: version.mname.clone(),
-        rname,
-        default_ttl: version.default_ttl,
-        serial: new_serial,
-        refresh: version.refresh,
-        retry: version.retry,
-        expire: version.expire,
-        dnssec_policy_id: zone.dnssec_policy_id,
-        minimum_ttl: version.minimum_ttl,
-        created_at: zone.created_at,
-    })
-}
-
 impl ZoneService {
     /// List a zone's versions (serial history), newest serial first. Unless
     /// `all`, signer-only serials (DNSSEC re-signs, rollovers) are skipped —
@@ -388,7 +359,27 @@ impl ZoneService {
             .ok_or_else(|| ServiceError::version_not_found(zone.name.as_str(), target_serial))?;
 
             let new_serial = generate_serial(Some(zone.serial))?;
-            let restored_zone = restored_zone_from_version(&zone, &version, new_serial)?;
+            // SOA metadata comes back from the version; identity and creation
+            // time are not part of one and stay.
+            let rname = SoaMailbox::from_encoded(&version.rname)
+                .to_email()
+                .map_err(|e| {
+                    ServiceError::internal(format!("Failed to decode version rname: {}", e))
+                })?;
+            let restored_zone = Zone {
+                id: zone.id,
+                name: zone.name.clone(),
+                mname: version.mname.clone(),
+                rname,
+                default_ttl: version.default_ttl,
+                serial: new_serial,
+                refresh: version.refresh,
+                retry: version.retry,
+                expire: version.expire,
+                dnssec_policy_id: zone.dnssec_policy_id,
+                minimum_ttl: version.minimum_ttl,
+                created_at: zone.created_at,
+            };
             let soa_changed = zone.soa_metadata_differs(&restored_zone);
 
             let current_records =

--- a/crates/bindizr-service/src/zone/token_policy.rs
+++ b/crates/bindizr-service/src/zone/token_policy.rs
@@ -8,10 +8,7 @@ use chrono::Utc;
 use crate::{
     authorization::Caller,
     error::ServiceError,
-    model::{
-        api_token::ApiToken,
-        zone_token_policy::{ZoneTokenPolicy, ZoneTokenPolicyWithToken},
-    },
+    model::zone_token_policy::{ZoneTokenPolicy, ZoneTokenPolicyWithToken},
     policy_pattern::{normalize_pattern, normalize_types},
     repository::RepositoryService,
     token::normalize_token_name,
@@ -35,7 +32,9 @@ impl ZoneTokenPolicyService {
         caller.require_global("manage token policies")?;
 
         let zone = ZoneService::lookup_by_name(zone_name).await?;
-        let token = lookup_token(token_name).await?;
+        let token = RepositoryService::get_api_token_by_name(&normalize_token_name(token_name)?)
+            .await?
+            .ok_or_else(|| ServiceError::token_not_found(token_name))?;
 
         if token.is_global {
             return Err(ServiceError::invalid_input(format!(
@@ -108,10 +107,4 @@ impl ZoneTokenPolicyService {
 
         RepositoryService::delete_zone_token_policy(policy.id).await
     }
-}
-
-async fn lookup_token(token_name: &str) -> Result<ApiToken, ServiceError> {
-    RepositoryService::get_api_token_by_name(&normalize_token_name(token_name)?)
-        .await?
-        .ok_or_else(|| ServiceError::token_not_found(token_name))
 }

--- a/crates/bindizr/Cargo.toml
+++ b/crates/bindizr/Cargo.toml
@@ -25,15 +25,12 @@ path = "src/main.rs"
 bindizr-core = { path = "../bindizr-core", version = "0.1.0-beta.7" }
 bindizr-db = { path = "../bindizr-db", version = "0.1.0-beta.7" }
 bindizr-service = { path = "../bindizr-service", version = "0.1.0-beta.7" }
-async-trait.workspace = true
 axum.workspace = true
-base64.workspace = true
 chrono.workspace = true
 clap.workspace = true
 log.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-rand.workspace = true
 serde_yaml.workspace = true
 sha2.workspace = true
 thiserror.workspace = true

--- a/crates/bindizr/src/api/dnssec.rs
+++ b/crates/bindizr/src/api/dnssec.rs
@@ -17,11 +17,9 @@ use crate::api::{
     RequestCaller, ZoneNameParam, error::ApiError, middleware::body_parser::JsonBody,
 };
 
-/// Route group for zone DNSSEC endpoints.
 pub(crate) struct DnssecApi;
 
 impl DnssecApi {
-    /// Build the router for zone DNSSEC endpoints.
     pub(crate) async fn routes() -> Router {
         Router::new()
             .route("/zones/{name}/dnssec", routing::get(get_dnssec_status))

--- a/crates/bindizr/src/api/dnssec_policy.rs
+++ b/crates/bindizr/src/api/dnssec_policy.rs
@@ -16,11 +16,9 @@ use serde::Deserialize;
 
 use crate::api::{RequestCaller, error::ApiError, middleware::body_parser::JsonBody};
 
-/// Route group for DNSSEC policy endpoints.
 pub(crate) struct DnssecPolicyApi;
 
 impl DnssecPolicyApi {
-    /// Build the router for DNSSEC policy endpoints.
     pub(crate) async fn routes() -> Router {
         Router::new()
             .route("/dnssec-policies", routing::get(get_dnssec_policies))

--- a/crates/bindizr/src/api/external_dns.rs
+++ b/crates/bindizr/src/api/external_dns.rs
@@ -20,12 +20,10 @@ use crate::api::{
     middleware::body_parser::{JsonBody, MAX_UPLOAD_BODY_BYTES},
 };
 
-/// Route group for the ExternalDNS provider endpoints, registered only when
-/// `api.external_dns_enabled` is set.
+/// Registered only when `api.external_dns_enabled` is set.
 pub(crate) struct ExternalDnsApi;
 
 impl ExternalDnsApi {
-    /// Build the router for ExternalDNS endpoints.
     pub(crate) async fn routes() -> Router {
         Router::new()
             .route("/external-dns/zones", routing::get(get_external_dns_zones))

--- a/crates/bindizr/src/api/mod.rs
+++ b/crates/bindizr/src/api/mod.rs
@@ -25,14 +25,11 @@ use router::ApiRouter;
 use serde::Deserialize;
 use tokio::net::TcpListener;
 
-/// Path parameters addressing a zone by name.
 #[derive(Debug, Deserialize)]
 pub(crate) struct ZoneNameParam {
     pub(crate) name: String,
 }
 
-/// Path parameters addressing one of a zone's policies by zone name and
-/// policy id.
 #[derive(Debug, Deserialize)]
 pub(crate) struct ZonePolicyParam {
     pub(crate) name: String,

--- a/crates/bindizr/src/api/notify.rs
+++ b/crates/bindizr/src/api/notify.rs
@@ -11,11 +11,9 @@ use bindizr_service::{
 
 use crate::api::{RequestCaller, error::ApiError, middleware::body_parser::JsonBody};
 
-/// Route group for NOTIFY endpoints.
 pub(crate) struct NotifyApi;
 
 impl NotifyApi {
-    /// Build the router for NOTIFY endpoints.
     pub(crate) async fn routes() -> Router {
         Router::new().route("/zones/notify", routing::post(notify_zones))
     }

--- a/crates/bindizr/src/api/record.rs
+++ b/crates/bindizr/src/api/record.rs
@@ -21,11 +21,9 @@ use crate::api::{
     middleware::body_parser::{JsonBody, MAX_UPLOAD_BODY_BYTES},
 };
 
-/// Route group for record endpoints.
 pub(crate) struct RecordApi;
 
 impl RecordApi {
-    /// Build the router for record endpoints.
     pub(crate) async fn routes() -> Router {
         Router::new()
             .route("/records", routing::get(get_records))
@@ -234,13 +232,11 @@ pub(crate) async fn create_records_bulk(
     Ok((status, Json(response)).into_response())
 }
 
-/// Path parameters scoped to a zone.
 #[derive(Debug, Deserialize)]
 pub(crate) struct ZoneScopedParam {
     zone_name: String,
 }
 
-/// Path parameters addressing a record by id.
 #[derive(Debug, Deserialize)]
 pub(crate) struct RecordIdParam {
     record_id: i32,

--- a/crates/bindizr/src/api/router.rs
+++ b/crates/bindizr/src/api/router.rs
@@ -15,7 +15,6 @@ use super::{
     token_policy::TokenPolicyApi, tsig_key::TsigKeyApi, zone::ZoneApi,
 };
 
-/// HTTP API router assembling all route groups.
 pub(crate) struct ApiRouter;
 
 impl ApiRouter {

--- a/crates/bindizr/src/api/token_policy.rs
+++ b/crates/bindizr/src/api/token_policy.rs
@@ -18,11 +18,9 @@ use crate::api::{
     middleware::body_parser::JsonBody,
 };
 
-/// Route group for zone token-policy endpoints.
 pub(crate) struct TokenPolicyApi;
 
 impl TokenPolicyApi {
-    /// Build the router for zone token-policy endpoints.
     pub(crate) async fn routes() -> Router {
         Router::new()
             .route(

--- a/crates/bindizr/src/api/tsig_key.rs
+++ b/crates/bindizr/src/api/tsig_key.rs
@@ -21,11 +21,9 @@ use crate::api::{
     middleware::body_parser::JsonBody,
 };
 
-/// Route group for TSIG key and zone TSIG policy endpoints.
 pub(crate) struct TsigKeyApi;
 
 impl TsigKeyApi {
-    /// Build the router for TSIG key and zone TSIG policy endpoints.
     pub(crate) async fn routes() -> Router {
         Router::new()
             .route("/tsig-keys", routing::get(get_tsig_keys))

--- a/crates/bindizr/src/api/zone.rs
+++ b/crates/bindizr/src/api/zone.rs
@@ -23,11 +23,9 @@ use crate::api::{
     middleware::body_parser::{JsonBody, MAX_UPLOAD_BODY_BYTES},
 };
 
-/// Route group for zone endpoints.
 pub(crate) struct ZoneApi;
 
 impl ZoneApi {
-    /// Build the router for zone endpoints.
     pub(crate) async fn routes() -> Router {
         Router::new()
             .route("/zones", routing::get(get_zones))
@@ -79,7 +77,6 @@ pub(crate) async fn get_zone_status(
     Ok((StatusCode::OK, Json(status)).into_response())
 }
 
-/// Query parameters for the zone export.
 #[derive(Deserialize)]
 pub(crate) struct ExportZoneQuery {
     pub(crate) signed: Option<bool>,
@@ -205,7 +202,6 @@ pub(crate) async fn rollback_zone(
     Ok((StatusCode::OK, Json(response)).into_response())
 }
 
-/// Query parameters for listing zone versions.
 #[derive(Debug, Deserialize)]
 pub(crate) struct VersionListQuery {
     limit: Option<u32>,
@@ -214,14 +210,12 @@ pub(crate) struct VersionListQuery {
     offset: Option<u64>,
 }
 
-/// Path parameters addressing a zone version by zone name and serial.
 #[derive(Debug, Deserialize)]
 pub(crate) struct ZoneVersionParam {
     name: String,
     serial: i32,
 }
 
-/// Query parameters selecting the two serials to diff.
 #[derive(Debug, Deserialize)]
 pub(crate) struct VersionDiffQuery {
     from: i32,
@@ -445,7 +439,6 @@ pub(crate) async fn import_zone(
     Ok((StatusCode::OK, Json(response)).into_response())
 }
 
-/// Query parameters for fetching a zone.
 #[derive(Debug, Deserialize)]
 pub(crate) struct GetZoneQuery {
     records: Option<bool>,

--- a/crates/bindizr/src/cli/commands/mod.rs
+++ b/crates/bindizr/src/cli/commands/mod.rs
@@ -3,7 +3,6 @@ pub(crate) mod dnssec_policy;
 pub(crate) mod doctor;
 pub(crate) mod record;
 pub(crate) mod restart;
-pub(crate) mod start;
 pub(crate) mod status;
 pub(crate) mod stop;
 pub(crate) mod token;

--- a/crates/bindizr/src/cli/commands/start.rs
+++ b/crates/bindizr/src/cli/commands/start.rs
@@ -1,6 +1,0 @@
-use crate::daemon;
-
-/// Handle the `start` subcommand by bootstrapping the daemon in the foreground.
-pub(crate) async fn handle_command(config: Option<String>) -> Result<(), String> {
-    daemon::bootstrap(config.as_deref()).await
-}

--- a/crates/bindizr/src/cli/commands/zone/token_policy.rs
+++ b/crates/bindizr/src/cli/commands/zone/token_policy.rs
@@ -83,7 +83,8 @@ pub(crate) async fn handle_command(
                     ZonePolicyListParams { zone_name: name },
                 )
                 .await?;
-            print_token_policies(&response.data)?;
+            let policies: Vec<GetZoneTokenPolicyResponse> = parse_response(&response.data)?;
+            print_table(policies.iter().map(ZoneTokenPolicyRow::from).collect());
         }
         ZoneTokenPolicyCommand::Remove { name, id } => {
             let response = client
@@ -98,14 +99,6 @@ pub(crate) async fn handle_command(
             println!("{}", response.message);
         }
     }
-
-    Ok(())
-}
-
-fn print_token_policies(data: &serde_json::Value) -> Result<(), String> {
-    let policies: Vec<GetZoneTokenPolicyResponse> = parse_response(data)?;
-
-    print_table(policies.iter().map(ZoneTokenPolicyRow::from).collect());
 
     Ok(())
 }

--- a/crates/bindizr/src/cli/commands/zone/tsig_policy.rs
+++ b/crates/bindizr/src/cli/commands/zone/tsig_policy.rs
@@ -86,7 +86,8 @@ pub(crate) async fn handle_command(
                     ZonePolicyListParams { zone_name: name },
                 )
                 .await?;
-            print_tsig_policies(&response.data)?;
+            let policies: Vec<GetZoneTsigPolicyResponse> = parse_response(&response.data)?;
+            print_table(policies.iter().map(ZoneTsigPolicyRow::from).collect());
         }
         ZoneTsigPolicyCommand::Remove { name, id } => {
             let response = client
@@ -101,14 +102,6 @@ pub(crate) async fn handle_command(
             println!("{}", response.message);
         }
     }
-
-    Ok(())
-}
-
-fn print_tsig_policies(data: &serde_json::Value) -> Result<(), String> {
-    let policies: Vec<GetZoneTsigPolicyResponse> = parse_response(data)?;
-
-    print_table(policies.iter().map(ZoneTsigPolicyRow::from).collect());
 
     Ok(())
 }

--- a/crates/bindizr/src/cli/mod.rs
+++ b/crates/bindizr/src/cli/mod.rs
@@ -8,9 +8,12 @@ mod output;
 
 use clap::{Parser, Subcommand};
 
-use crate::cli::commands::{
-    config::ConfigCommand, dnssec_policy::DnssecPolicyCommand, record::RecordCommand,
-    token::TokenCommand, tsig_key::TsigKeyCommand, zone::ZoneCommand,
+use crate::{
+    cli::commands::{
+        config::ConfigCommand, dnssec_policy::DnssecPolicyCommand, record::RecordCommand,
+        token::TokenCommand, tsig_key::TsigKeyCommand, zone::ZoneCommand,
+    },
+    daemon,
 };
 
 /// Top-level CLI argument parser.
@@ -79,7 +82,7 @@ pub async fn execute() {
     let args = Args::parse();
 
     if let Err(e) = match args.command {
-        Command::Start { config } => commands::start::handle_command(config)
+        Command::Start { config } => daemon::bootstrap(config.as_deref())
             .await
             .map_err(error::CliError::from),
         Command::Status => commands::status::handle_command().await,

--- a/crates/bindizr/src/cli/output/format.rs
+++ b/crates/bindizr/src/cli/output/format.rs
@@ -2,7 +2,6 @@ use bindizr_service::types::PaginatedResponse;
 use serde::{Deserialize, de::DeserializeOwned};
 use tabled::{Table, Tabled, settings::Style};
 
-/// Output format for CLI results.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OutputFormat {
     Json,

--- a/crates/bindizr/src/cli/output/table.rs
+++ b/crates/bindizr/src/cli/output/table.rs
@@ -29,7 +29,6 @@ fn value_text(value: &RecordValueRequest) -> String {
     }
 }
 
-/// Table row for zone display.
 #[derive(Debug, Tabled)]
 pub(crate) struct ZoneRow {
     #[tabled(rename = "ID")]
@@ -59,7 +58,6 @@ impl From<&GetZoneResponse> for ZoneRow {
     }
 }
 
-/// Table row for record display.
 #[derive(Debug, Tabled)]
 pub(crate) struct RecordRow {
     #[tabled(rename = "ID", display = "display_option_i32")]
@@ -92,7 +90,6 @@ impl From<&GetRecordResponse> for RecordRow {
     }
 }
 
-/// Table row for DNSSEC signing-key display.
 #[derive(Debug, Tabled)]
 pub(crate) struct DnssecKeyRow {
     #[tabled(rename = "ID")]
@@ -127,7 +124,6 @@ impl From<&DnssecKeyInfo> for DnssecKeyRow {
     }
 }
 
-/// Table row for DNSSEC policy display.
 #[derive(Debug, Tabled)]
 pub(crate) struct DnssecPolicyRow {
     #[tabled(rename = "NAME")]
@@ -170,7 +166,6 @@ impl From<&GetDnssecPolicyResponse> for DnssecPolicyRow {
     }
 }
 
-/// Table row for zone version display.
 #[derive(Debug, Tabled)]
 pub(crate) struct VersionRow {
     #[tabled(rename = "SERIAL")]
@@ -224,7 +219,6 @@ impl From<&VersionRecordResponse> for VersionRecordRow {
     }
 }
 
-/// Table row for rollback result summaries.
 #[derive(Debug, Tabled)]
 pub(crate) struct RollbackSummaryRow {
     #[tabled(rename = "TARGET-SERIAL")]
@@ -257,7 +251,6 @@ impl From<&RollbackZoneResponse> for RollbackSummaryRow {
     }
 }
 
-/// Table row for per-secondary zone sync status.
 #[derive(Debug, Tabled)]
 pub(crate) struct SecondaryStatusRow {
     #[tabled(rename = "ADDRESS")]
@@ -302,7 +295,6 @@ impl SecondaryStatusRow {
     }
 }
 
-/// Table row for zone-file import summaries.
 #[derive(Debug, Tabled)]
 pub(crate) struct ImportSummaryRow {
     #[tabled(rename = "PARSED")]
@@ -332,7 +324,6 @@ impl From<&ImportSummary> for ImportSummaryRow {
     }
 }
 
-/// Table row for API token display.
 #[derive(Debug, Tabled)]
 pub(crate) struct TokenRow {
     #[tabled(rename = "NAME")]
@@ -359,7 +350,6 @@ impl From<&GetTokenResponse> for TokenRow {
     }
 }
 
-/// Table row for TSIG key display.
 #[derive(Debug, Tabled)]
 pub(crate) struct TsigKeyRow {
     #[tabled(rename = "ID")]
@@ -386,7 +376,6 @@ impl From<&GetTsigKeyResponse> for TsigKeyRow {
     }
 }
 
-/// Table row for zone token policy display.
 #[derive(Debug, Tabled)]
 pub(crate) struct ZoneTokenPolicyRow {
     #[tabled(rename = "ID")]
@@ -410,7 +399,6 @@ impl From<&GetZoneTokenPolicyResponse> for ZoneTokenPolicyRow {
     }
 }
 
-/// Table row for zone TSIG policy display.
 #[derive(Debug, Tabled)]
 pub(crate) struct ZoneTsigPolicyRow {
     #[tabled(rename = "ID")]

--- a/crates/bindizr/src/dns/error.rs
+++ b/crates/bindizr/src/dns/error.rs
@@ -37,10 +37,3 @@ impl From<ServiceError> for XfrError {
         XfrError::DatabaseError(e.to_string())
     }
 }
-
-/// DNS-plane failures reaching a service-facing surface (status, doctor).
-impl From<XfrError> for ServiceError {
-    fn from(e: XfrError) -> Self {
-        ServiceError::internal(e.to_string())
-    }
-}

--- a/crates/bindizr/src/dns/server/catalog/mod.rs
+++ b/crates/bindizr/src/dns/server/catalog/mod.rs
@@ -30,7 +30,10 @@ pub(crate) async fn generate_catalog_zone() -> Result<(Zone, Vec<String>), XfrEr
     log_info!("Catalog zone contains {} member zones", member_zones.len());
 
     // The catalog zone is virtual (no DB row).
-    let serial = generate_catalog_serial(&member_zones, &all_zones).await?;
+    let digest = catalog_digest(&member_zones, &all_zones);
+    let base_serial = all_zones.iter().map(|z| z.serial).max().unwrap_or(1);
+    let serial =
+        ZoneService::advance_catalog_serial(CATALOG_ZONE_NAME, &digest, base_serial).await?;
 
     let catalog_zone = Zone {
         id: 0,
@@ -48,12 +51,6 @@ pub(crate) async fn generate_catalog_zone() -> Result<(Zone, Vec<String>), XfrEr
     };
 
     Ok((catalog_zone, member_zones))
-}
-
-async fn generate_catalog_serial(member_zones: &[String], zones: &[Zone]) -> Result<i32, XfrError> {
-    let digest = catalog_digest(member_zones, zones);
-    let base_serial = zones.iter().map(|z| z.serial).max().unwrap_or(1);
-    Ok(ZoneService::advance_catalog_serial(CATALOG_ZONE_NAME, &digest, base_serial).await?)
 }
 
 fn catalog_digest(member_zones: &[String], zones: &[Zone]) -> String {

--- a/crates/bindizr/src/dns/server/ixfr.rs
+++ b/crates/bindizr/src/dns/server/ixfr.rs
@@ -14,7 +14,6 @@ use tokio::net::TcpStream;
 use super::{axfr, catalog};
 use crate::dns::error::XfrError;
 
-/// Handles an IXFR request.
 pub(crate) async fn handle_ixfr(
     stream: &mut TcpStream,
     query: &message::ParsedQuery,
@@ -212,8 +211,9 @@ enum IxfrSendError {
     Partial(XfrError),
 }
 
-/// Sends an IXFR response with incremental changes, reporting whether a failure
-/// left the stream dirty so the caller can decide about AXFR fallback.
+/// Streams the IXFR answers across multiple TCP messages, flushing before the
+/// 64 KiB wire limit, and reports whether a failure left the stream dirty so
+/// the caller can decide about AXFR fallback.
 async fn send_ixfr_response(
     stream: &mut TcpStream,
     query: &message::ParsedQuery,
@@ -225,15 +225,106 @@ async fn send_ixfr_response(
     let mut builder = message::DnsMessageBuilder::new(query.query_id, &query.qname, Rtype::IXFR);
     let mut messages_sent = 0usize;
 
-    let result = stream_ixfr_body(
-        stream,
-        &mut builder,
-        &mut messages_sent,
-        zone,
-        client_serial,
-        changes,
-        versions_by_serial,
-    )
+    let result = async {
+        let current_version = versions_by_serial
+            .get(&bindizr_core::dns::serial_to_u32(zone.serial)?)
+            .ok_or_else(|| {
+                XfrError::ProtocolError("Missing current serial SOA version for IXFR".to_string())
+            })?;
+
+        // Initial SOA (current serial).
+        crate::dns::wire::add_answer_and_flush_if_needed(
+            &mut builder,
+            stream,
+            &mut messages_sent,
+            |builder| builder.add_version_soa(current_version),
+        )
+        .await?;
+
+        let mut changes_by_serial: HashMap<u32, Vec<&ZoneChange>> = HashMap::new();
+        for change in changes {
+            let serial = bindizr_core::dns::serial_to_u32(change.serial)?;
+            changes_by_serial.entry(serial).or_default().push(change);
+        }
+
+        let mut serials: Vec<u32> = changes_by_serial.keys().copied().collect();
+        serials.sort();
+
+        for (idx, &serial) in serials.iter().enumerate() {
+            let serial_changes = &changes_by_serial[&serial];
+
+            let old_serial = if idx == 0 {
+                client_serial
+            } else {
+                serials[idx - 1]
+            };
+
+            // Old SOA (deletion section marker).
+            let old_soa = versions_by_serial.get(&old_serial).ok_or_else(|| {
+                XfrError::ProtocolError(format!(
+                    "Missing old SOA version for serial {}",
+                    old_serial
+                ))
+            })?;
+            crate::dns::wire::add_answer_and_flush_if_needed(
+                &mut builder,
+                stream,
+                &mut messages_sent,
+                |builder| builder.add_version_soa(old_soa),
+            )
+            .await?;
+
+            for change in serial_changes
+                .iter()
+                .filter(|c| c.operation == ChangeOperation::Del)
+            {
+                crate::dns::wire::add_answer_and_flush_if_needed(
+                    &mut builder,
+                    stream,
+                    &mut messages_sent,
+                    |builder| add_change(builder, change, &zone.name),
+                )
+                .await?;
+            }
+
+            // New SOA (addition section marker).
+            let new_soa = versions_by_serial.get(&serial).ok_or_else(|| {
+                XfrError::ProtocolError(format!("Missing new SOA version for serial {}", serial))
+            })?;
+            crate::dns::wire::add_answer_and_flush_if_needed(
+                &mut builder,
+                stream,
+                &mut messages_sent,
+                |builder| builder.add_version_soa(new_soa),
+            )
+            .await?;
+
+            for change in serial_changes
+                .iter()
+                .filter(|c| c.operation == ChangeOperation::Add)
+            {
+                crate::dns::wire::add_answer_and_flush_if_needed(
+                    &mut builder,
+                    stream,
+                    &mut messages_sent,
+                    |builder| add_change(builder, change, &zone.name),
+                )
+                .await?;
+            }
+        }
+
+        // Final SOA (current serial).
+        crate::dns::wire::add_answer_and_flush_if_needed(
+            &mut builder,
+            stream,
+            &mut messages_sent,
+            |builder| builder.add_version_soa(current_version),
+        )
+        .await?;
+        messages_sent += crate::dns::wire::flush_if_not_empty(&mut builder, stream).await?;
+
+        Ok::<(), XfrError>(())
+    }
     .await;
 
     match result {
@@ -245,109 +336,6 @@ async fn send_ixfr_response(
         Err(err) if messages_sent > 0 => Err(IxfrSendError::Partial(err)),
         Err(err) => Err(IxfrSendError::NotStarted(err)),
     }
-}
-
-/// Streams the IXFR answers across multiple TCP messages, flushing before the
-/// 64 KiB wire limit. `messages_sent` distinguishes a pre-write failure from a
-/// mid-stream one.
-async fn stream_ixfr_body(
-    stream: &mut TcpStream,
-    builder: &mut message::DnsMessageBuilder,
-    messages_sent: &mut usize,
-    zone: &bindizr_core::model::zone::Zone,
-    client_serial: u32,
-    changes: &[ZoneChange],
-    versions_by_serial: &HashMap<u32, ZoneVersion>,
-) -> Result<(), XfrError> {
-    let current_version = versions_by_serial
-        .get(&bindizr_core::dns::serial_to_u32(zone.serial)?)
-        .ok_or_else(|| {
-            XfrError::ProtocolError("Missing current serial SOA version for IXFR".to_string())
-        })?;
-
-    // Initial SOA (current serial).
-    crate::dns::wire::add_answer_and_flush_if_needed(builder, stream, messages_sent, |builder| {
-        builder.add_version_soa(current_version)
-    })
-    .await?;
-
-    let mut changes_by_serial: HashMap<u32, Vec<&ZoneChange>> = HashMap::new();
-    for change in changes {
-        let serial = bindizr_core::dns::serial_to_u32(change.serial)?;
-        changes_by_serial.entry(serial).or_default().push(change);
-    }
-
-    let mut serials: Vec<u32> = changes_by_serial.keys().copied().collect();
-    serials.sort();
-
-    for (idx, &serial) in serials.iter().enumerate() {
-        let serial_changes = &changes_by_serial[&serial];
-
-        let old_serial = if idx == 0 {
-            client_serial
-        } else {
-            serials[idx - 1]
-        };
-
-        // Old SOA (deletion section marker).
-        let old_soa = versions_by_serial.get(&old_serial).ok_or_else(|| {
-            XfrError::ProtocolError(format!("Missing old SOA version for serial {}", old_serial))
-        })?;
-        crate::dns::wire::add_answer_and_flush_if_needed(
-            builder,
-            stream,
-            messages_sent,
-            |builder| builder.add_version_soa(old_soa),
-        )
-        .await?;
-
-        for change in serial_changes
-            .iter()
-            .filter(|c| c.operation == ChangeOperation::Del)
-        {
-            crate::dns::wire::add_answer_and_flush_if_needed(
-                builder,
-                stream,
-                messages_sent,
-                |builder| add_change(builder, change, &zone.name),
-            )
-            .await?;
-        }
-
-        // New SOA (addition section marker).
-        let new_soa = versions_by_serial.get(&serial).ok_or_else(|| {
-            XfrError::ProtocolError(format!("Missing new SOA version for serial {}", serial))
-        })?;
-        crate::dns::wire::add_answer_and_flush_if_needed(
-            builder,
-            stream,
-            messages_sent,
-            |builder| builder.add_version_soa(new_soa),
-        )
-        .await?;
-
-        for change in serial_changes
-            .iter()
-            .filter(|c| c.operation == ChangeOperation::Add)
-        {
-            crate::dns::wire::add_answer_and_flush_if_needed(
-                builder,
-                stream,
-                messages_sent,
-                |builder| add_change(builder, change, &zone.name),
-            )
-            .await?;
-        }
-    }
-
-    // Final SOA (current serial).
-    crate::dns::wire::add_answer_and_flush_if_needed(builder, stream, messages_sent, |builder| {
-        builder.add_version_soa(current_version)
-    })
-    .await?;
-    *messages_sent += crate::dns::wire::flush_if_not_empty(builder, stream).await?;
-
-    Ok(())
 }
 
 fn add_change(

--- a/crates/bindizr/src/dns/server/mod.rs
+++ b/crates/bindizr/src/dns/server/mod.rs
@@ -39,7 +39,6 @@ pub(crate) async fn initialize() {
     }
 }
 
-/// Returns `true` if `qtype` is a zone-transfer query (AXFR or IXFR).
 pub(crate) fn is_xfr_query_type(qtype: Rtype) -> bool {
     matches!(qtype, Rtype::AXFR | Rtype::IXFR)
 }

--- a/crates/bindizr/src/dns/server/nsupdate/update/mod.rs
+++ b/crates/bindizr/src/dns/server/nsupdate/update/mod.rs
@@ -100,8 +100,16 @@ pub(crate) async fn apply_update(
         let update = DynamicUpdate {
             zone_name: zone_name.to_string(),
             key,
-            prerequisites: decode_prerequisites(&request.prerequisites, query_data)?,
-            updates: decode_updates(&request.updates, query_data)?,
+            prerequisites: request
+                .prerequisites
+                .iter()
+                .map(|rr| decode_prerequisite(rr, query_data))
+                .collect::<Result<_, _>>()?,
+            updates: request
+                .updates
+                .iter()
+                .map(|rr| decode_update(rr, query_data))
+                .collect::<Result<_, _>>()?,
         };
 
         let changed = DynamicUpdateService::apply(update).await?;
@@ -147,16 +155,6 @@ async fn authenticate_request(
     )?);
 
     Ok(key)
-}
-
-fn decode_prerequisites(
-    prerequisites: &[UpdateRecord],
-    query_data: &[u8],
-) -> Result<Vec<Prerequisite>, UpdateError> {
-    prerequisites
-        .iter()
-        .map(|rr| decode_prerequisite(rr, query_data))
-        .collect()
 }
 
 /// One prerequisite RR, with the wire shapes of RFC 2136, Section 2.4 enforced:
@@ -212,16 +210,6 @@ fn decode_prerequisite(rr: &UpdateRecord, query_data: &[u8]) -> Result<Prerequis
             other
         ))),
     }
-}
-
-fn decode_updates(
-    updates: &[UpdateRecord],
-    query_data: &[u8],
-) -> Result<Vec<UpdateOp>, UpdateError> {
-    updates
-        .iter()
-        .map(|rr| decode_update(rr, query_data))
-        .collect()
 }
 
 fn decode_update(rr: &UpdateRecord, query_data: &[u8]) -> Result<UpdateOp, UpdateError> {

--- a/crates/bindizr/src/dns/server/zone_cache.rs
+++ b/crates/bindizr/src/dns/server/zone_cache.rs
@@ -46,10 +46,6 @@ struct CachedZone {
 static CACHE: OnceLock<Mutex<HashMap<i32, CachedZone>>> = OnceLock::new();
 static CLOCK: AtomicU64 = AtomicU64::new(0);
 
-fn cache() -> &'static Mutex<HashMap<i32, CachedZone>> {
-    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
 fn tick() -> u64 {
     CLOCK.fetch_add(1, Ordering::Relaxed)
 }
@@ -101,7 +97,8 @@ async fn load_content(zone: Zone) -> Result<Option<(Zone, ZoneContent)>, Service
 /// The cache holds no invariant a panicking thread could leave broken, so a
 /// poisoned lock is recovered rather than failing every later query.
 fn locked_cache() -> std::sync::MutexGuard<'static, HashMap<i32, CachedZone>> {
-    cache()
+    CACHE
+        .get_or_init(|| Mutex::new(HashMap::new()))
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }

--- a/crates/bindizr/src/socket/client/mod.rs
+++ b/crates/bindizr/src/socket/client/mod.rs
@@ -16,7 +16,6 @@ use crate::{
 pub(crate) struct DaemonSocketClient;
 
 impl DaemonSocketClient {
-    /// Create a new [`DaemonSocketClient`].
     pub(crate) fn new() -> Self {
         DaemonSocketClient
     }
@@ -42,7 +41,6 @@ impl DaemonSocketClient {
         }
     }
 
-    /// Query the daemon's status.
     pub(crate) async fn status(&self) -> Result<DaemonStatusResponse, CliError> {
         let res = self.send_control_command(DaemonCommandKind::Status).await?;
         serde_json::from_value(res.data)

--- a/crates/bindizr/src/socket/server/notify.rs
+++ b/crates/bindizr/src/socket/server/notify.rs
@@ -9,7 +9,6 @@ use crate::socket::{server::parse_params, types::DaemonResponse};
 pub(crate) async fn notify_zone(data: &serde_json::Value) -> Result<DaemonResponse, ServiceError> {
     let request: NotifyZoneRequest = parse_params(data)?;
 
-    // The daemon socket is root-local, so commands run as the global caller.
     ZoneService::notify(
         &Caller::Global,
         request.zone_name.as_deref(),

--- a/crates/bindizr/src/socket/server/tests.rs
+++ b/crates/bindizr/src/socket/server/tests.rs
@@ -13,30 +13,22 @@ fn try_bind_test_socket(socket_path: &str) -> Option<UnixListener> {
 
 #[test]
 fn parse_params_rejects_wrongly_typed_fields() {
-    use bindizr_service::types::CreateTsigKeyRequest;
+    use bindizr_service::types::{CreateTsigKeyRequest, RollbackZoneRequest};
 
     // Absent/null optional fields deserialize as their defaults...
     let ok: CreateTsigKeyRequest =
         parse_params(&json!({ "name": "k", "algorithm": null, "secret": null })).unwrap();
     assert!(!ok.global);
-
-    // ...but a present field of the wrong type is rejected instead of being
-    // silently dropped (which would e.g. generate a secret instead of
-    // importing one).
-    let err =
-        parse_params::<CreateTsigKeyRequest>(&json!({ "name": "k", "secret": 123 })).unwrap_err();
-    assert_eq!(err.code, bindizr_service::error::ErrorCode::InvalidInput);
-}
-
-#[test]
-fn parse_params_rejects_a_wrongly_typed_rollback_dry_run() {
-    use bindizr_service::types::RollbackZoneRequest;
-
     let ok: RollbackZoneRequest = parse_params(&json!({ "serial": 7 })).unwrap();
     assert!(!ok.dry_run);
 
-    // A wrongly typed dry_run once defaulted to false, applying a rollback the
-    // caller asked to preview.
+    // ...but a present field of the wrong type is rejected instead of being
+    // silently dropped, which would generate a secret instead of importing
+    // one, or apply a rollback the caller asked to preview (a wrongly typed
+    // dry_run once defaulted to false).
+    let err =
+        parse_params::<CreateTsigKeyRequest>(&json!({ "name": "k", "secret": 123 })).unwrap_err();
+    assert_eq!(err.code, bindizr_service::error::ErrorCode::InvalidInput);
     for dry_run in [json!("true"), json!(1)] {
         let err = parse_params::<RollbackZoneRequest>(&json!({ "serial": 7, "dry_run": dry_run }))
             .unwrap_err();

--- a/crates/bindizr/src/socket/types.rs
+++ b/crates/bindizr/src/socket/types.rs
@@ -84,31 +84,26 @@ pub(crate) struct DaemonResponse {
 // a renamed field breaks at compile time. A payload that is exactly a service
 // request type is sent as that type.
 
-/// Payload addressing a zone by name.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct ZoneNameParams {
     pub(crate) name: String,
 }
 
-/// Payload addressing a record by id.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct RecordIdParams {
     pub(crate) id: i32,
 }
 
-/// Payload addressing a TSIG key by name.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct TsigKeyNameParams {
     pub(crate) name: String,
 }
 
-/// Payload addressing a DNSSEC policy by name.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct DnssecPolicyNameParams {
     pub(crate) name: String,
 }
 
-/// Payload for editing a DNSSEC policy's timing.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct UpdateDnssecPolicyParams {
     pub(crate) name: String,
@@ -116,26 +111,22 @@ pub(crate) struct UpdateDnssecPolicyParams {
     pub(crate) request: UpdateDnssecPolicyRequest,
 }
 
-/// Payload addressing an API token by name.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct TokenNameParams {
     pub(crate) name: String,
 }
 
-/// Payload addressing a zone's policies.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct ZonePolicyListParams {
     pub(crate) zone_name: String,
 }
 
-/// Payload addressing one policy row within a zone.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct RemoveZonePolicyParams {
     pub(crate) zone_name: String,
     pub(crate) id: i32,
 }
 
-/// Payload for granting a TSIG key a policy on a zone.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct AddZoneTsigPolicyParams {
     pub(crate) zone_name: String,
@@ -143,7 +134,6 @@ pub(crate) struct AddZoneTsigPolicyParams {
     pub(crate) request: CreateZoneTsigPolicyRequest,
 }
 
-/// Payload for granting a token a policy on a zone.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct AddZoneTokenPolicyParams {
     pub(crate) zone_name: String,
@@ -151,7 +141,6 @@ pub(crate) struct AddZoneTokenPolicyParams {
     pub(crate) request: CreateZoneTokenPolicyRequest,
 }
 
-/// Payload for importing zone-file text into a zone.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct ExportZoneFileParams {
     pub(crate) name: String,
@@ -173,7 +162,6 @@ pub(crate) struct ImportZoneFromServerParams {
     pub(crate) request: ImportZoneFromServerRequest,
 }
 
-/// Payload for inserting records into a zone in one transaction.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct BulkCreateRecordsParams {
     pub(crate) zone_name: String,
@@ -181,7 +169,6 @@ pub(crate) struct BulkCreateRecordsParams {
     pub(crate) request: CreateBulkRecordsRequest,
 }
 
-/// Payload for patching a zone.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct UpdateZoneParams {
     pub(crate) name: String,
@@ -189,7 +176,6 @@ pub(crate) struct UpdateZoneParams {
     pub(crate) patch: UpdateZonePatch,
 }
 
-/// Payload for patching a record.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct UpdateRecordParams {
     pub(crate) id: i32,
@@ -197,7 +183,6 @@ pub(crate) struct UpdateRecordParams {
     pub(crate) patch: UpdateRecordPatch,
 }
 
-/// Payload for rolling a zone back to a version serial.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct RollbackZoneParams {
     pub(crate) name: String,
@@ -205,7 +190,6 @@ pub(crate) struct RollbackZoneParams {
     pub(crate) request: RollbackZoneRequest,
 }
 
-/// Payload for listing a zone's versions.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct ListZoneVersionsParams {
     pub(crate) name: String,
@@ -215,7 +199,6 @@ pub(crate) struct ListZoneVersionsParams {
     pub(crate) all: bool,
 }
 
-/// Payload addressing one of a zone's versions.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct ZoneVersionParams {
     pub(crate) name: String,
@@ -231,7 +214,6 @@ pub(crate) struct DiffZoneVersionsParams {
     pub(crate) to_serial: Option<i32>,
 }
 
-/// Payload for enabling DNSSEC on a zone.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct EnableZoneDnssecParams {
     pub(crate) zone_name: String,
@@ -239,7 +221,6 @@ pub(crate) struct EnableZoneDnssecParams {
     pub(crate) request: EnableDnssecRequest,
 }
 
-/// Payload for starting a DNSSEC key rollover on a zone.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct RolloverZoneDnssecParams {
     pub(crate) zone_name: String,
@@ -247,7 +228,6 @@ pub(crate) struct RolloverZoneDnssecParams {
     pub(crate) request: RolloverDnssecRequest,
 }
 
-/// Payload for importing one BIND key pair into a zone.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct ImportZoneDnssecKeyParams {
     pub(crate) zone_name: String,
@@ -255,7 +235,6 @@ pub(crate) struct ImportZoneDnssecKeyParams {
     pub(crate) request: ImportDnssecKeyRequest,
 }
 
-/// Payload for moving a signed zone to another DNSSEC policy.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct SetZoneDnssecPolicyParams {
     pub(crate) zone_name: String,


### PR DESCRIPTION
- inline helpers that only labelled a section of their one caller: the IXFR body streamer, the nsupdate add path, catalog serial derivation, the rollback zone literal, CLI policy printers, and pass-through wrappers (RecordService::list_tx, cli/commands/start.rs)
- drop the unused XfrError -> ServiceError impl and the async-trait, base64, and rand dependencies of the bindizr crate
- merge tests that covered one path under several names and delete the plain serde round-trips in bindizr-external-dns
- delete doc comments that only restate the item name; fix the list_by_state_eligible_before doc, which described the wrong column

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and streamlined technical documentation across DNS, database, API, and command-line components.
  * Updated DNSSEC and TSIG algorithm descriptions and expanded explanatory comments for serial handling and catalog-zone identifiers.

* **Refactor**
  * Simplified configuration loading, DNS updates, zone rollback, transfers, and CLI output processing without changing supported behavior.
  * Improved transaction handling for DNS update prerequisites.
  * Removed unused internal helpers and redundant dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->