### PR TITLE
fix(build): turn off split-debuginfo in the dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,5 +69,10 @@ tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.7.0", features = ["cors"] }
 utoipa = { version = "5.5", features = ["axum_extras", "chrono", "yaml"] }
 
+[profile.dev]
+# The macOS default, "unpacked", leaves stale .o files in target/debug/deps,
+# and rustc scans that directory on every invocation.
+split-debuginfo = "off"
+
 [profile.release]
 panic = "unwind"


### PR DESCRIPTION
## Why

On macOS the dev profile defaults to `split-debuginfo = "unpacked"`, which keeps every codegen unit's `.o` file in `target/debug/deps` and never removes stale ones. rustc reads that directory in full on every invocation (`-L dependency=` search path), so the build got slower as leftovers accumulated: 1.6M `.o` files, 210 GB, and a fully cached `cargo build -p bindizr` taking 11m46s with 50s of CPU.

## Change

`[profile.dev] split-debuginfo = "off"` in the root `Cargo.toml`. Object files are discarded after linking, so nothing piles up. Library crates' debuginfo remains reachable through the rlibs; only the bin crate's own code loses line info. Linux CI already uses `off`, so it is unaffected.

## Measured after `cargo clean`

| `cargo build -p bindizr` | before | after |
|---|---|---|
| cached, no change | 11m46s | 0.15s |
| after a code change in bindizr-core | minutes | 2.7s |
| clean full build | – | 1m27s |
