### PR TITLE
fix: daemon shutdown, DNS response codes, and record storage defects from an audit

### DIFF
--- a/crates/bindizr-core/src/config/mod.rs
+++ b/crates/bindizr-core/src/config/mod.rs
@@ -250,7 +250,8 @@ impl std::str::FromStr for LogLevel {
 pub fn initialize(conf_file_path: Option<&str>) -> Result<(), String> {
     let conf_file_path = resolve_config_path(conf_file_path);
 
-    println!("Initializing configuration from file: {}", conf_file_path);
+    // Predates the logger, which is installed from the config this loads.
+    eprintln!("Initializing configuration from file: {}", conf_file_path);
 
     let bindizr_config = load_config_file(&conf_file_path)?;
     BINDIZR_CONFIG.get_or_init(|| bindizr_config);

--- a/crates/bindizr-core/src/config/mod.rs
+++ b/crates/bindizr-core/src/config/mod.rs
@@ -197,7 +197,7 @@ fn default_notify_retries() -> u32 {
 }
 
 fn default_notify_timeout_secs() -> u64 {
-    5
+    3
 }
 
 /// Logging settings.

--- a/crates/bindizr-core/src/config/tests.rs
+++ b/crates/bindizr-core/src/config/tests.rs
@@ -107,7 +107,7 @@ fn from_raw_defaults_missing_optional_fields() {
     assert!(parsed.dns.notify_after_update);
     assert!(!parsed.dns.notify_on_startup);
     assert_eq!(parsed.dns.notify_retries, 3);
-    assert_eq!(parsed.dns.notify_timeout_secs, 5);
+    assert_eq!(parsed.dns.notify_timeout_secs, 3);
     assert!(!parsed.dns.nsupdate_allow_unsigned);
     assert_eq!(parsed.dns.journal_retention_days, 365);
 }

--- a/crates/bindizr-core/src/dns/message/mod.rs
+++ b/crates/bindizr-core/src/dns/message/mod.rs
@@ -383,6 +383,12 @@ fn parse_name(name: &str) -> Result<Name<Vec<u8>>, String> {
     Name::from_octets(wire).map_err(|e| format!("Invalid domain name '{}': {}", name, e))
 }
 
+/// Whether the message is itself a response (QR=1). Answering one lets a
+/// spoofed source aim the reply at a third party.
+pub fn is_response(message: &[u8]) -> bool {
+    Message::from_octets(message).is_ok_and(|message| message.header().qr())
+}
+
 /// A DNS query parsed once at the listener and handed to every handler.
 pub struct ParsedQuery {
     pub qname: Name<Vec<u8>>,

--- a/crates/bindizr-core/src/dns/message/mod.rs
+++ b/crates/bindizr-core/src/dns/message/mod.rs
@@ -391,6 +391,7 @@ pub struct ParsedQuery {
     pub qtype: Rtype,
     pub client_serial: Option<u32>,
     pub query_id: u16,
+    pub opcode: Opcode,
 }
 
 impl ParsedQuery {
@@ -399,6 +400,7 @@ impl ParsedQuery {
             .map_err(|e| format!("Failed to parse DNS message: {}", e))?;
 
         let query_id = message.header().id();
+        let opcode = message.header().opcode();
 
         let question = message
             .first_question()
@@ -431,6 +433,7 @@ impl ParsedQuery {
             qtype,
             client_serial,
             query_id,
+            opcode,
         })
     }
 
@@ -455,6 +458,8 @@ impl ParsedQuery {
         let header = builder.header_mut();
         header.set_id(self.query_id);
         header.set_qr(true);
+        // RFC 1035, Section 4.1.1: a response echoes the request's opcode.
+        header.set_opcode(self.opcode);
         set(header);
 
         let mut question = builder.question();

--- a/crates/bindizr-core/src/dns/message/tests.rs
+++ b/crates/bindizr-core/src/dns/message/tests.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use domain::base::{MessageBuilder, Name, iana::Rtype};
 
-use super::{DNS_TCP_MAX_SIZE, DnsMessageBuilder, ParsedQuery, encode_tcp_message};
+use super::{DNS_TCP_MAX_SIZE, DnsMessageBuilder, ParsedQuery, encode_tcp_message, is_response};
 use crate::model::record::RecordType;
 
 #[test]
@@ -75,4 +75,20 @@ fn truncated_response_echoes_the_question_with_tc_set() {
     assert_eq!(response[3] & 0x0f, 0);
     assert_eq!(&response[4..6], &1u16.to_be_bytes());
     assert_eq!(&response[6..8], &0u16.to_be_bytes());
+}
+
+#[test]
+fn is_response_separates_a_reply_from_a_query() {
+    let qname = Name::<Vec<u8>>::from_str("example.com.").unwrap();
+
+    let mut builder = MessageBuilder::new_vec();
+    builder.header_mut().set_id(1234);
+    let mut question = builder.question();
+    question.push((&qname, Rtype::A)).unwrap();
+    let query = question.finish();
+    assert!(!is_response(&query));
+
+    let parsed = ParsedQuery::parse(&query).expect("a question-only query parses");
+    let reply = parsed.error_response(super::Rcode::REFUSED);
+    assert!(is_response(&reply));
 }

--- a/crates/bindizr-core/src/dns/zonefile.rs
+++ b/crates/bindizr-core/src/dns/zonefile.rs
@@ -3,7 +3,7 @@
 use domain::{
     base::iana::{Class, Rtype},
     rdata::ZoneRecordData,
-    zonefile::inplace::{Entry, Zonefile},
+    zonefile::inplace::{Entry, Error as ZoneFileError, Zonefile},
 };
 
 use crate::{dns::name::to_fqdn_lowercase, model::record::RecordType};
@@ -39,7 +39,8 @@ pub struct ParsedZoneFile {
 pub fn parse_zone_file(content: &str, zone_name: &str, default_ttl: i32) -> ParsedZoneFile {
     let origin_fqdn = to_fqdn_lowercase(zone_name);
 
-    // Feed $ORIGIN/$TTL as directives so the parser resolves relative names and TTLs.
+    // Feed $ORIGIN/$TTL as directives so the parser resolves relative names and
+    // TTLs. PRELUDE_LINES counts them.
     let mut buffer = format!("$ORIGIN {origin_fqdn}\n$TTL {default_ttl}\n");
     buffer.push_str(content);
     if !buffer.ends_with('\n') {
@@ -149,13 +150,33 @@ pub fn parse_zone_file(content: &str, zone_name: &str, default_ttl: i32) -> Pars
             }
             Ok(None) => break,
             Err(e) => {
-                errors.push(format!("failed to parse zone file: {e}"));
+                errors.push(format!(
+                    "failed to parse zone file: {}",
+                    to_input_line_message(&e)
+                ));
+                // domain documents the scanner as invalid once an entry fails.
                 break;
             }
         }
     }
 
     ParsedZoneFile { rrs, errors }
+}
+
+/// Directives `parse_zone_file` prepends before handing the text to the parser.
+const PRELUDE_LINES: usize = 2;
+
+/// Restate a parser error in the submitted text's line numbering. `Error` keeps
+/// its position private, so its `{line}:{col}: {reason}` rendering is all there is.
+fn to_input_line_message(err: &ZoneFileError) -> String {
+    let message = err.to_string();
+    match message.split_once(':') {
+        Some((line, rest)) => match line.parse::<usize>() {
+            Ok(line) if line > PRELUDE_LINES => format!("{}:{}", line - PRELUDE_LINES, rest),
+            _ => message,
+        },
+        None => message,
+    }
 }
 
 #[cfg(test)]
@@ -177,6 +198,22 @@ mod tests {
                 .iter()
                 .any(|rr| rr.record_type == RecordType::TXT),
             "the non-UTF-8 TXT record should not have been stored"
+        );
+    }
+
+    #[test]
+    fn parse_error_names_the_line_of_the_submitted_text() {
+        // An unknown rtype is caught where it sits; an rdata error is reported
+        // at the end of the entry, which would blur what this pins down.
+        let parsed = parse_zone_file(
+            "ok IN A 192.0.2.1\nbad !!! IN A 192.0.2.2\n",
+            "example.com",
+            3600,
+        );
+        assert!(
+            parsed.errors.iter().any(|e| e.contains(": 2:")),
+            "expected the error to name line 2, got: {:?}",
+            parsed.errors
         );
     }
 

--- a/crates/bindizr-core/src/logger/mod.rs
+++ b/crates/bindizr-core/src/logger/mod.rs
@@ -53,7 +53,7 @@ impl log::Log for Logger {
 
     fn log(&self, record: &Record<'_>) {
         if self.enabled(record.metadata()) {
-            let log_message = if self.log_level == Level::Debug {
+            let log_message = if self.log_level >= Level::Debug {
                 format!(
                     "{} - {}: {}\n",
                     record.level(),
@@ -98,5 +98,5 @@ pub fn initialize_with_level(level: config::LogLevel) {
     }
     log::set_max_level(log_level.to_level_filter());
 
-    println!("Console logging level: {}", log_level);
+    log::info!("Console logging level: {}", log_level);
 }

--- a/crates/bindizr-core/src/model/record/mod.rs
+++ b/crates/bindizr-core/src/model/record/mod.rs
@@ -248,6 +248,17 @@ impl RecordType {
         self.canonical_value(left, left_priority) == self.canonical_value(right, right_priority)
     }
 
+    /// MX and SRV encode a preference in their rdata, so an omitted one takes
+    /// the default serving applies; other types pass through to be rejected.
+    pub fn stored_priority(&self, priority: Option<i32>) -> Option<i32> {
+        match self {
+            RecordType::MX | RecordType::SRV => {
+                Some(priority.unwrap_or(i32::from(DEFAULT_PRIORITY)))
+            }
+            _ => priority,
+        }
+    }
+
     /// Canonical form used only to compare two values, never to store them.
     pub fn canonical_value<'a>(
         &self,

--- a/crates/bindizr-db/src/schema.rs
+++ b/crates/bindizr-db/src/schema.rs
@@ -57,6 +57,7 @@ pub(crate) fn mysql_table_creation_queries() -> Vec<&'static str> {
             priority INT,
             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
             zone_id INT NOT NULL,
+            CHECK ((record_type IN ('MX', 'SRV')) = (priority IS NOT NULL)),
             FOREIGN KEY (zone_id) REFERENCES zones(id) ON DELETE CASCADE,
             INDEX idx_records_zone_name (zone_id, name),
             INDEX idx_records_zone_type (zone_id, record_type)
@@ -257,6 +258,7 @@ pub(crate) fn postgres_table_creation_queries() -> Vec<&'static str> {
             priority INTEGER,
             created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
             zone_id INTEGER NOT NULL,
+            CHECK ((record_type IN ('MX', 'SRV')) = (priority IS NOT NULL)),
             FOREIGN KEY (zone_id) REFERENCES zones(id) ON DELETE CASCADE
         );
         "#,
@@ -481,6 +483,7 @@ pub(crate) fn sqlite_table_creation_queries() -> Vec<&'static str> {
             priority INTEGER,
             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
             zone_id INTEGER NOT NULL,
+            CHECK ((record_type IN ('MX', 'SRV')) = (priority IS NOT NULL)),
             FOREIGN KEY (zone_id) REFERENCES zones(id) ON DELETE CASCADE
         );
         "#,

--- a/crates/bindizr-db/src/schema.rs
+++ b/crates/bindizr-db/src/schema.rs
@@ -79,7 +79,8 @@ pub(crate) fn mysql_table_creation_queries() -> Vec<&'static str> {
             CHECK ((derived = TRUE AND record_value IS NULL AND record_rdata IS NOT NULL)
                 OR (derived = FALSE AND record_value IS NOT NULL AND record_rdata IS NULL)),
             FOREIGN KEY (zone_id) REFERENCES zones(id) ON DELETE CASCADE,
-            INDEX idx_zone_serial (zone_id, serial)
+            INDEX idx_zone_serial (zone_id, serial),
+            INDEX idx_zone_journal_created (created_at)
         );
         "#,
         r#"
@@ -96,6 +97,7 @@ pub(crate) fn mysql_table_creation_queries() -> Vec<&'static str> {
             minimum_ttl INT NOT NULL,
             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
             UNIQUE KEY uq_zone_serial (zone_id, serial),
+            INDEX idx_zone_versions_created (created_at),
             FOREIGN KEY (zone_id) REFERENCES zones(id) ON DELETE CASCADE
         );
         "#,
@@ -287,6 +289,9 @@ pub(crate) fn postgres_table_creation_queries() -> Vec<&'static str> {
         CREATE INDEX IF NOT EXISTS idx_zone_serial ON zone_journal(zone_id, serial);
         "#,
         r#"
+        CREATE INDEX IF NOT EXISTS idx_zone_journal_created ON zone_journal(created_at);
+        "#,
+        r#"
         CREATE TABLE IF NOT EXISTS zone_versions (
             id SERIAL PRIMARY KEY,
             zone_id INTEGER NOT NULL,
@@ -302,6 +307,9 @@ pub(crate) fn postgres_table_creation_queries() -> Vec<&'static str> {
             UNIQUE(zone_id, serial),
             FOREIGN KEY (zone_id) REFERENCES zones(id) ON DELETE CASCADE
         );
+        "#,
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_zone_versions_created ON zone_versions(created_at);
         "#,
         r#"
         CREATE TABLE IF NOT EXISTS api_tokens (
@@ -505,6 +513,9 @@ pub(crate) fn sqlite_table_creation_queries() -> Vec<&'static str> {
         CREATE INDEX IF NOT EXISTS idx_zone_serial ON zone_journal(zone_id, serial);
         "#,
         r#"
+        CREATE INDEX IF NOT EXISTS idx_zone_journal_created ON zone_journal(created_at);
+        "#,
+        r#"
         CREATE TABLE IF NOT EXISTS zone_versions (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             zone_id INTEGER NOT NULL,
@@ -520,6 +531,9 @@ pub(crate) fn sqlite_table_creation_queries() -> Vec<&'static str> {
             UNIQUE(zone_id, serial),
             FOREIGN KEY (zone_id) REFERENCES zones(id) ON DELETE CASCADE
         );
+        "#,
+        r#"
+        CREATE INDEX IF NOT EXISTS idx_zone_versions_created ON zone_versions(created_at);
         "#,
         r#"
         CREATE TABLE IF NOT EXISTS api_tokens (

--- a/crates/bindizr-service/src/dnssec/maintenance.rs
+++ b/crates/bindizr-service/src/dnssec/maintenance.rs
@@ -33,7 +33,14 @@ pub fn init_maintenance_scheduler() {
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
             interval.tick().await;
-            run_maintenance_pass().await;
+            // A panic in the pass would otherwise unwind the scheduler itself.
+            if let Err(e) = tokio::spawn(run_maintenance_pass()).await {
+                log_error!("DNSSEC maintenance pass did not finish: {}", e);
+                metrics()
+                    .dnssec_maintenance_runs_total
+                    .with_label_values(&["panic"])
+                    .inc();
+            }
         }
     });
 }

--- a/crates/bindizr-service/src/dynamic_update/mod.rs
+++ b/crates/bindizr-service/src/dynamic_update/mod.rs
@@ -306,10 +306,10 @@ async fn apply_op(
                 &[Record {
                     id: 0,
                     name: owner,
-                    record_type: record_type.clone(),
                     value,
                     ttl: *ttl,
-                    priority: *priority,
+                    priority: record_type.stored_priority(*priority),
+                    record_type: record_type.clone(),
                     zone_id: zone.id,
                     created_at: Utc::now(),
                 }],

--- a/crates/bindizr-service/src/record/bulk.rs
+++ b/crates/bindizr-service/src/record/bulk.rs
@@ -62,6 +62,7 @@ pub(crate) fn parse_record(
     if let Some(ttl) = ttl {
         validate_record_ttl(ttl)?;
     }
+    let priority = record_type.stored_priority(priority);
     let value = value
         .to_encoded_value(&record_type, priority)
         .map_err(ServiceError::invalid_record_value)?;

--- a/crates/bindizr-service/src/record/create.rs
+++ b/crates/bindizr-service/src/record/create.rs
@@ -30,6 +30,7 @@ impl RecordService {
         let PreparedRecord {
             record_type,
             value: record_value,
+            priority,
             ..
         } = parse_record(
             &create_record_request.name,
@@ -90,7 +91,7 @@ impl RecordService {
                 &record_type,
                 &record_value,
                 ttl,
-                create_record_request.priority,
+                priority,
                 None,
             )?;
 
@@ -106,7 +107,7 @@ impl RecordService {
                     record_type,
                     value: record_value,
                     ttl,
-                    priority: create_record_request.priority,
+                    priority,
                     zone_id: zone.id,
                     created_at: Utc::now(),
                 }],

--- a/crates/bindizr-service/src/record/import.rs
+++ b/crates/bindizr-service/src/record/import.rs
@@ -220,10 +220,10 @@ impl RecordService {
                 desired.push(DesiredRecord {
                     prepared: PreparedRecord {
                         owner_name: rr.owner_fqdn,
+                        priority: rr.record_type.stored_priority(rr.priority),
                         record_type: rr.record_type,
                         value,
                         ttl: Some(rr.ttl),
-                        priority: rr.priority,
                     },
                     stored_name,
                 });

--- a/crates/bindizr-service/src/record/update.rs
+++ b/crates/bindizr-service/src/record/update.rs
@@ -57,7 +57,7 @@ impl RecordService {
             // Only MX/SRV carry a priority: given for another type it is the
             // error creation gives, and retyping to another type clears it.
             let priority = if matches!(record_type, RecordType::MX | RecordType::SRV) {
-                request.priority.or(existing.priority)
+                record_type.stored_priority(request.priority.or(existing.priority))
             } else if request.priority.is_some() {
                 return Err(ServiceError::invalid_record_value(format!(
                     "{} records do not take a priority",

--- a/crates/bindizr/src/api/mod.rs
+++ b/crates/bindizr/src/api/mod.rs
@@ -23,7 +23,9 @@ use bindizr_service::{authorization::Caller, error::ServiceError};
 use error::ApiError;
 use router::ApiRouter;
 use serde::Deserialize;
-use tokio::net::TcpListener;
+use tokio::{net::TcpListener, task::JoinHandle};
+
+use crate::shutdown::Shutdown;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct ZoneNameParam {
@@ -77,8 +79,10 @@ where
     }
 }
 
-/// Bind the HTTP API listener and spawn the axum server in the background.
-pub(crate) async fn initialize() -> Result<(), String> {
+/// Bind the HTTP API listener and spawn the axum server in the background. The
+/// returned handle finishes once `shutdown` fires and in-flight requests are
+/// answered.
+pub(crate) async fn initialize(shutdown: &Shutdown) -> Result<JoinHandle<()>, String> {
     let bindizr_config = config::bindizr_config();
     let addr = SocketAddr::from((
         bindizr_config.api.listen_addr,
@@ -91,11 +95,13 @@ pub(crate) async fn initialize() -> Result<(), String> {
 
     log_info!("HTTP API server listening on http://{}", addr);
 
-    tokio::spawn(async move {
-        if let Err(e) = axum::serve(listener, ApiRouter::routes().await).await {
+    let stop = shutdown.waiter();
+    Ok(tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, ApiRouter::routes().await)
+            .with_graceful_shutdown(stop)
+            .await
+        {
             log_error!("API server error: {:?}", e);
         }
-    });
-
-    Ok(())
+    }))
 }

--- a/crates/bindizr/src/daemon.rs
+++ b/crates/bindizr/src/daemon.rs
@@ -30,7 +30,7 @@ pub(crate) async fn bootstrap(config_file: Option<&str>) -> Result<(), String> {
 
     service::dnssec::init_maintenance_scheduler();
 
-    dns::initialize().await;
+    dns::initialize().await?;
 
     if config::bindizr_config().dns.notify_on_startup {
         match service::notify::send_notify(None).await {

--- a/crates/bindizr/src/daemon.rs
+++ b/crates/bindizr/src/daemon.rs
@@ -2,11 +2,18 @@
 //! stop, and re-executing itself on restart. The CLI only decides when to
 //! start it.
 
+use std::time::Duration;
+
 use bindizr_core::{config, log_error, log_info, logger};
 use bindizr_db as database;
 use bindizr_service as service;
+use tokio::signal::unix::{SignalKind, signal};
 
-use crate::{api, dns, socket};
+use crate::{api, dns, shutdown::Shutdown, socket};
+
+/// How long the servers that can finish on their own get before the daemon
+/// exits anyway.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Re-exec path captured at startup: after a package upgrade /proc/self/exe
 /// reads as a "(deleted)" path, while this path points at the replacement.
@@ -30,7 +37,8 @@ pub(crate) async fn bootstrap(config_file: Option<&str>) -> Result<(), String> {
 
     service::dnssec::init_maintenance_scheduler();
 
-    dns::initialize().await?;
+    let shutdown = Shutdown::new();
+    dns::initialize(&shutdown).await?;
 
     if config::bindizr_config().dns.notify_on_startup {
         match service::notify::send_notify(None).await {
@@ -44,14 +52,21 @@ pub(crate) async fn bootstrap(config_file: Option<&str>) -> Result<(), String> {
     log_info!("# systemctl start bindizr");
 
     let mut control_rx = socket::server::control::init();
-    socket::server::initialize().await?;
-    api::initialize().await?;
+    let socket_task = socket::server::initialize(&shutdown).await?;
+    let api_task = api::initialize(&shutdown).await?;
+
+    let mut terminate = signal(SignalKind::terminate())
+        .map_err(|e| format!("Failed to listen for SIGTERM: {}", e))?;
 
     loop {
         let control = tokio::select! {
             result = tokio::signal::ctrl_c() => {
                 result.map_err(|e| format!("Failed to listen for shutdown signal: {}", e))?;
-                log_info!("Shutdown signal received, exiting gracefully...");
+                log_info!("Interrupt received, shutting down...");
+                break;
+            }
+            _ = terminate.recv() => {
+                log_info!("SIGTERM received, shutting down...");
                 break;
             }
             control = control_rx.recv() => control,
@@ -69,6 +84,21 @@ pub(crate) async fn bootstrap(config_file: Option<&str>) -> Result<(), String> {
                 break;
             }
         }
+    }
+
+    shutdown.trigger();
+
+    // In-flight zone transfers are not waited on: a cut transfer is one the
+    // secondary discards and retries.
+    let drained = tokio::time::timeout(DRAIN_TIMEOUT, async {
+        let _ = tokio::join!(socket_task, api_task);
+    })
+    .await;
+    if drained.is_err() {
+        log_error!(
+            "Servers did not finish within {:?}, exiting anyway.",
+            DRAIN_TIMEOUT
+        );
     }
 
     Ok(())

--- a/crates/bindizr/src/dns/mod.rs
+++ b/crates/bindizr/src/dns/mod.rs
@@ -9,7 +9,7 @@ use std::{future::Future, io::ErrorKind, net::SocketAddr, time::Duration};
 
 use bindizr_core::{
     config,
-    dns::message::{self, Rtype},
+    dns::message::{self, Rcode, Rtype},
     log_error, log_info, log_warn,
 };
 use server::acl::SecondaryAcl;
@@ -158,11 +158,16 @@ async fn dispatch_tcp_query(
             .await
             .map_err(|e| format!("Failed to handle XFR TCP query: {}", e))?;
     } else {
+        // bindizr answers secondaries, not resolvers.
         log_info!(
-            "Ignoring non-XFR DNS TCP query from {} (qtype={:?})",
+            "Refusing out-of-scope DNS TCP query from {} (qtype={:?})",
             client_addr,
             query.qtype
         );
+        let response = query.error_response(Rcode::REFUSED);
+        wire::write_tcp_message(stream, &response)
+            .await
+            .map_err(|e| format!("Failed to refuse a DNS TCP query: {}", e))?;
     }
 
     Ok(())
@@ -213,14 +218,20 @@ async fn run_udp_server(
             if let Err(e) = server::soa::handle_udp_soa(&socket, client_addr, &query).await {
                 log_warn!("Failed to handle SOA UDP query from {}: {}", client_addr, e);
             }
-        } else if server::is_xfr_query_type(query.qtype) {
-            match server::handle_udp_query(client_addr, &secondary_acl, &query).await {
-                Ok(response) => {
-                    if let Err(e) = socket.send_to(&response, client_addr).await {
-                        log_warn!("Failed to answer XFR UDP query from {}: {}", client_addr, e);
-                    }
-                }
-                Err(e) => log_warn!("Refused XFR UDP query from {}: {}", client_addr, e),
+        } else {
+            let response = if server::is_xfr_query_type(query.qtype) {
+                server::handle_udp_query(client_addr, &secondary_acl, &query).await
+            } else {
+                log_info!(
+                    "Refusing out-of-scope DNS UDP query from {} (qtype={:?})",
+                    client_addr,
+                    query.qtype
+                );
+                query.error_response(Rcode::REFUSED)
+            };
+
+            if let Err(e) = socket.send_to(&response, client_addr).await {
+                log_warn!("Failed to answer DNS UDP query from {}: {}", client_addr, e);
             }
         }
     }

--- a/crates/bindizr/src/dns/mod.rs
+++ b/crates/bindizr/src/dns/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod error;
 pub(crate) mod server;
 pub(crate) mod wire;
 
-use std::{io::ErrorKind, net::SocketAddr, time::Duration};
+use std::{future::Future, io::ErrorKind, net::SocketAddr, time::Duration};
 
 use bindizr_core::{
     config,
@@ -18,10 +18,12 @@ use tokio::{
     time::timeout,
 };
 
+use crate::shutdown::Shutdown;
+
 const TCP_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Initializes the DNS service: prepares the catalog zone and spawns the TCP and UDP servers.
-pub(crate) async fn initialize() -> Result<(), String> {
+pub(crate) async fn initialize(shutdown: &Shutdown) -> Result<(), String> {
     server::initialize().await;
 
     let bindizr_config = config::bindizr_config();
@@ -43,14 +45,16 @@ pub(crate) async fn initialize() -> Result<(), String> {
     log_info!("DNS TCP server listening on {}", listen_addr);
     log_info!("DNS UDP server listening on {}", listen_addr);
 
+    let tcp_stop = shutdown.waiter();
     tokio::spawn(async move {
-        if let Err(e) = run_tcp_server(tcp_listener, tcp_secondary_acl).await {
+        if let Err(e) = run_tcp_server(tcp_listener, tcp_secondary_acl, tcp_stop).await {
             log_error!("DNS TCP server error: {}", e);
         }
     });
 
+    let udp_stop = shutdown.waiter();
     tokio::spawn(async move {
-        if let Err(e) = run_udp_server(udp_socket, secondary_acl).await {
+        if let Err(e) = run_udp_server(udp_socket, secondary_acl, udp_stop).await {
             log_error!("DNS UDP server error: {}", e);
         }
     });
@@ -58,9 +62,23 @@ pub(crate) async fn initialize() -> Result<(), String> {
     Ok(())
 }
 
-async fn run_tcp_server(listener: TcpListener, secondary_acl: SecondaryAcl) -> Result<(), String> {
+async fn run_tcp_server(
+    listener: TcpListener,
+    secondary_acl: SecondaryAcl,
+    stop: impl Future<Output = ()>,
+) -> Result<(), String> {
+    tokio::pin!(stop);
+
     loop {
-        match listener.accept().await {
+        let accepted = tokio::select! {
+            accepted = listener.accept() => accepted,
+            () = &mut stop => {
+                log_info!("DNS TCP server stopping");
+                return Ok(());
+            }
+        };
+
+        match accepted {
             Ok((stream, client_addr)) => {
                 let allowed = secondary_acl.clone();
                 tokio::spawn(async move {
@@ -150,11 +168,24 @@ async fn dispatch_tcp_query(
     Ok(())
 }
 
-async fn run_udp_server(socket: UdpSocket, secondary_acl: SecondaryAcl) -> Result<(), String> {
+async fn run_udp_server(
+    socket: UdpSocket,
+    secondary_acl: SecondaryAcl,
+    stop: impl Future<Output = ()>,
+) -> Result<(), String> {
     let mut buf = vec![0u8; 65535];
+    tokio::pin!(stop);
 
     loop {
-        let (len, client_addr) = match socket.recv_from(&mut buf).await {
+        let received = tokio::select! {
+            received = socket.recv_from(&mut buf) => received,
+            () = &mut stop => {
+                log_info!("DNS UDP server stopping");
+                return Ok(());
+            }
+        };
+
+        let (len, client_addr) = match received {
             Ok(v) => v,
             Err(e) => {
                 log_error!("Failed to receive DNS UDP packet: {}", e);

--- a/crates/bindizr/src/dns/mod.rs
+++ b/crates/bindizr/src/dns/mod.rs
@@ -9,7 +9,7 @@ use std::{future::Future, io::ErrorKind, net::SocketAddr, time::Duration};
 
 use bindizr_core::{
     config,
-    dns::message::{self, Rcode, Rtype},
+    dns::message::{self, Opcode, Rcode, Rtype},
     log_error, log_info, log_warn,
 };
 use server::acl::SecondaryAcl;
@@ -149,6 +149,18 @@ async fn dispatch_tcp_query(
         }
     };
 
+    if query.opcode != Opcode::QUERY {
+        log_info!(
+            "Refusing DNS TCP opcode {:?} from {}",
+            query.opcode,
+            client_addr
+        );
+        let response = query.error_response(Rcode::NOTIMP);
+        return wire::write_tcp_message(stream, &response)
+            .await
+            .map_err(|e| format!("Failed to answer an unsupported DNS TCP opcode: {}", e));
+    }
+
     if query.qtype == Rtype::SOA {
         server::soa::handle_tcp_soa(stream, client_addr, &query)
             .await
@@ -213,6 +225,19 @@ async fn run_udp_server(
             Ok(query) => query,
             Err(_) => continue,
         };
+
+        if query.opcode != Opcode::QUERY {
+            log_info!(
+                "Refusing DNS UDP opcode {:?} from {}",
+                query.opcode,
+                client_addr
+            );
+            let response = query.error_response(Rcode::NOTIMP);
+            if let Err(e) = socket.send_to(&response, client_addr).await {
+                log_warn!("Failed to answer DNS UDP query from {}: {}", client_addr, e);
+            }
+            continue;
+        }
 
         if query.qtype == Rtype::SOA {
             if let Err(e) = server::soa::handle_udp_soa(&socket, client_addr, &query).await {

--- a/crates/bindizr/src/dns/mod.rs
+++ b/crates/bindizr/src/dns/mod.rs
@@ -135,6 +135,11 @@ async fn dispatch_tcp_query(
     secondary_acl: &SecondaryAcl,
     query_data: &[u8],
 ) -> Result<(), String> {
+    if message::is_response(query_data) {
+        log_warn!("Ignoring a DNS TCP response from {}", client_addr);
+        return Ok(());
+    }
+
     // nsupdate owns its own parsing (including TSIG); everything else shares
     // one upfront parse.
     if server::nsupdate::is_nsupdate(query_data) {
@@ -211,6 +216,11 @@ async fn run_udp_server(
         };
 
         let query_data = &buf[..len];
+
+        if message::is_response(query_data) {
+            log_warn!("Ignoring a DNS UDP response from {}", client_addr);
+            continue;
+        }
 
         if server::nsupdate::is_nsupdate(query_data) {
             if let Err(e) =

--- a/crates/bindizr/src/dns/mod.rs
+++ b/crates/bindizr/src/dns/mod.rs
@@ -21,7 +21,7 @@ use tokio::{
 const TCP_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Initializes the DNS service: prepares the catalog zone and spawns the TCP and UDP servers.
-pub(crate) async fn initialize() {
+pub(crate) async fn initialize() -> Result<(), String> {
     server::initialize().await;
 
     let bindizr_config = config::bindizr_config();
@@ -33,29 +33,32 @@ pub(crate) async fn initialize() {
     let secondary_acl = SecondaryAcl::from_config();
     let tcp_secondary_acl = secondary_acl.clone();
 
+    let tcp_listener = TcpListener::bind(listen_addr)
+        .await
+        .map_err(|e| format!("Failed to bind DNS TCP listener on {}: {}", listen_addr, e))?;
+    let udp_socket = UdpSocket::bind(listen_addr)
+        .await
+        .map_err(|e| format!("Failed to bind DNS UDP socket on {}: {}", listen_addr, e))?;
+
+    log_info!("DNS TCP server listening on {}", listen_addr);
+    log_info!("DNS UDP server listening on {}", listen_addr);
+
     tokio::spawn(async move {
-        if let Err(e) = run_tcp_server(listen_addr, tcp_secondary_acl).await {
+        if let Err(e) = run_tcp_server(tcp_listener, tcp_secondary_acl).await {
             log_error!("DNS TCP server error: {}", e);
         }
     });
 
     tokio::spawn(async move {
-        if let Err(e) = run_udp_server(listen_addr, secondary_acl).await {
+        if let Err(e) = run_udp_server(udp_socket, secondary_acl).await {
             log_error!("DNS UDP server error: {}", e);
         }
     });
+
+    Ok(())
 }
 
-async fn run_tcp_server(
-    listen_addr: SocketAddr,
-    secondary_acl: SecondaryAcl,
-) -> Result<(), String> {
-    let listener = TcpListener::bind(listen_addr)
-        .await
-        .map_err(|e| format!("Failed to bind DNS TCP listener on {}: {}", listen_addr, e))?;
-
-    log_info!("DNS TCP server listening on {}", listen_addr);
-
+async fn run_tcp_server(listener: TcpListener, secondary_acl: SecondaryAcl) -> Result<(), String> {
     loop {
         match listener.accept().await {
             Ok((stream, client_addr)) => {
@@ -147,16 +150,7 @@ async fn dispatch_tcp_query(
     Ok(())
 }
 
-async fn run_udp_server(
-    listen_addr: SocketAddr,
-    secondary_acl: SecondaryAcl,
-) -> Result<(), String> {
-    let socket = UdpSocket::bind(listen_addr)
-        .await
-        .map_err(|e| format!("Failed to bind DNS UDP socket on {}: {}", listen_addr, e))?;
-
-    log_info!("DNS UDP server listening on {}", listen_addr);
-
+async fn run_udp_server(socket: UdpSocket, secondary_acl: SecondaryAcl) -> Result<(), String> {
     let mut buf = vec![0u8; 65535];
 
     loop {

--- a/crates/bindizr/src/dns/server/mod.rs
+++ b/crates/bindizr/src/dns/server/mod.rs
@@ -69,7 +69,11 @@ pub(crate) async fn handle_tcp_query(
 
     if let Err(err) = validate_secondary_acl(client_ip, secondary_acl).await {
         record_xfr_metric("refused");
-        return Err(err);
+        log_warn!("Refused XFR TCP query from {}: {}", client_ip, err);
+        // RFC 5936, Section 2.2.1: refuse with an RCODE, not a dropped connection.
+        let response = query.error_response(Rcode::REFUSED);
+        wire::write_tcp_message(stream, &response).await?;
+        return Ok(());
     }
 
     log_info!(
@@ -113,9 +117,12 @@ pub(crate) async fn handle_udp_query(
     client_addr: SocketAddr,
     secondary_acl: &acl::SecondaryAcl,
     query: &message::ParsedQuery,
-) -> Result<Vec<u8>, XfrError> {
-    validate_secondary_acl(client_addr.ip(), secondary_acl).await?;
-    Ok(query.truncated_response())
+) -> Vec<u8> {
+    if let Err(err) = validate_secondary_acl(client_addr.ip(), secondary_acl).await {
+        log_warn!("Refused XFR UDP query from {}: {}", client_addr.ip(), err);
+        return query.error_response(Rcode::REFUSED);
+    }
+    query.truncated_response()
 }
 
 async fn validate_secondary_acl(

--- a/crates/bindizr/src/lib.rs
+++ b/crates/bindizr/src/lib.rs
@@ -7,6 +7,7 @@ mod cli;
 mod daemon;
 mod dns;
 mod net;
+mod shutdown;
 mod socket;
 
 pub use cli::execute;

--- a/crates/bindizr/src/shutdown.rs
+++ b/crates/bindizr/src/shutdown.rs
@@ -1,0 +1,36 @@
+//! The signal every front end stops on.
+
+use std::future::Future;
+
+use tokio::sync::watch;
+
+/// A watch, not a broadcast, so a server that subscribes after the trigger
+/// still sees it.
+#[derive(Clone)]
+pub(crate) struct Shutdown {
+    tx: watch::Sender<bool>,
+}
+
+impl Shutdown {
+    pub(crate) fn new() -> Self {
+        Self {
+            tx: watch::channel(false).0,
+        }
+    }
+
+    pub(crate) fn trigger(&self) {
+        let _ = self.tx.send(true);
+    }
+
+    /// Resolves once [`Shutdown::trigger`] has been called, before or after.
+    pub(crate) fn waiter(&self) -> impl Future<Output = ()> + Send + 'static {
+        let mut rx = self.tx.subscribe();
+        async move {
+            // `changed` only reports transitions, so test the current value first.
+            if *rx.borrow_and_update() {
+                return;
+            }
+            let _ = rx.changed().await;
+        }
+    }
+}

--- a/crates/bindizr/src/socket/server/mod.rs
+++ b/crates/bindizr/src/socket/server/mod.rs
@@ -25,11 +25,15 @@ use tokio::{
     fs,
     io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader},
     net::{UnixListener, UnixStream},
+    task::JoinHandle,
 };
 
-use crate::socket::{
-    FALLBACK_SOCKET_FILE_PATH, SOCKET_FILE_PATH,
-    types::{DaemonCommand, DaemonCommandKind},
+use crate::{
+    shutdown::Shutdown,
+    socket::{
+        FALLBACK_SOCKET_FILE_PATH, SOCKET_FILE_PATH,
+        types::{DaemonCommand, DaemonCommandKind},
+    },
 };
 
 /// Upper bound on a single command line, so a buggy or malicious client cannot
@@ -160,16 +164,25 @@ async fn handle_client(stream: UnixStream) {
     }
 }
 
-/// Bind the daemon's Unix socket and spawn the connection accept loop.
-pub(crate) async fn initialize() -> Result<(), String> {
+/// Bind the daemon's Unix socket and spawn the connection accept loop. The
+/// returned handle finishes once `shutdown` fires and the socket file is gone.
+pub(crate) async fn initialize(shutdown: &Shutdown) -> Result<JoinHandle<()>, String> {
     status::mark_start_time();
     let (socket_path, listener) = bind_daemon_socket().await?;
 
     log_info!("Daemon socket server listening on {}", socket_path);
 
-    tokio::spawn(async move {
+    let stop = shutdown.waiter();
+    Ok(tokio::spawn(async move {
+        tokio::pin!(stop);
+
         loop {
-            match listener.accept().await {
+            let accepted = tokio::select! {
+                accepted = listener.accept() => accepted,
+                () = &mut stop => break,
+            };
+
+            match accepted {
                 Ok((stream, _)) => {
                     tokio::spawn(async move {
                         handle_client(stream).await;
@@ -180,9 +193,13 @@ pub(crate) async fn initialize() -> Result<(), String> {
                 }
             }
         }
-    });
 
-    Ok(())
+        drop(listener);
+        if let Err(e) = fs::remove_file(&socket_path).await {
+            log_warn!("Failed to remove the daemon socket {}: {}", socket_path, e);
+        }
+        log_info!("Daemon socket server stopped");
+    }))
 }
 
 /// Socket paths tried in order when the daemon starts.

--- a/packaging/scripts/build_packages.sh
+++ b/packaging/scripts/build_packages.sh
@@ -24,7 +24,8 @@ mkdir -p "$TMP_DIR/usr/share/licenses/bindizr"
 # Copy files
 echo "Copying files..."
 install -D -m 755 target/x86_64-unknown-linux-musl/release/bindizr "$TMP_DIR/usr/bin/bindizr"
-install -p -m 644 bindizr.conf.toml "$TMP_DIR/etc/bindizr/bindizr.conf.toml"
+# Owner-only: the file carries the database URL, and the daemon runs as root.
+install -p -m 600 bindizr.conf.toml "$TMP_DIR/etc/bindizr/bindizr.conf.toml"
 install -p -m 644 packaging/bindizr.service "$TMP_DIR/usr/lib/systemd/system/bindizr.service"
 install -p -m 644 README.md "$TMP_DIR/usr/share/doc/bindizr/README.md"
 install -p -m 644 LICENSE "$TMP_DIR/usr/share/licenses/bindizr/LICENSE"


### PR DESCRIPTION
A codebase audit turned up a set of independent defects. Each commit is one
fix, verified against a running daemon where the behaviour is observable.

## Daemon lifecycle

- **SIGTERM was unhandled**, so systemd, docker, and Kubernetes stopped the
  daemon by the signal's default action: an instant exit that cut in-flight API
  requests and left the Unix socket file behind. A watch signal now reaches
  every server, the API drains what it already accepted, the DNS and socket
  accept loops stop, and the socket file is removed. Verified by holding a TCP
  connection open across SIGTERM and completing the request 1.5s later: 200 OK,
  then a clean exit. In-flight zone transfers stay untracked, since a cut
  transfer is one the secondary discards and retries.
- **A DNS listener that could not bind only logged a line** while the daemon
  reported a successful start and served no DNS at all. `/health` probes the
  database only, so an orchestrator saw it as healthy. Both listeners now bind
  before the spawn, the way the API listener already did.
- **A panic in the DNSSEC maintenance pass unwound the scheduler loop**, so
  re-signing, journal pruning, and ZSK rollover stopped for the life of the
  process with nothing reporting it. The pass runs in its own task now and a
  panic is logged and counted as `result="panic"`. Verified by injecting a
  panic: four consecutive panics, daemon alive, each one recorded.

## DNS protocol

- **An ACL-denied transfer got its TCP connection closed with no message**,
  where RFC 5936, Section 2.2.1 asks for REFUSED, and the UDP path sent nothing
  at all. A query for a type bindizr does not serve was logged and dropped,
  leaving the client to wait out its timeout. Both answer REFUSED now.
- **A NOTIFY was answered with the zone's SOA.** `ParsedQuery` never read the
  opcode, so opcode 4 with a SOA question fell into the SOA branch. Responses
  also hardcoded opcode QUERY, which RFC 1035, Section 4.1.1 asks to echo.
  Anything but QUERY, with UPDATE dispatched ahead of it, is NOTIMP.

## Records and storage

- **MX and SRV rows written without a priority kept NULL** while serving filled
  in 10, so nsupdate could not delete an MX by the preference the zone actually
  served, and `?priority=10` skipped it. The write paths resolve it the way
  serving would, and a CHECK constraint holds the pairing that only
  service-layer validation enforced before. Verified with the real `nsupdate`
  tool, before and after.
- **Retention pruning had no index to stand on.** `zone_journal` and
  `zone_versions` now index `created_at`. On Postgres both hourly prunes go
  from a full scan to reading only the rows past the cutoff.

## Smaller fixes

- Zone-file parse errors were reported two lines past the caller's own text,
  because `$ORIGIN` and `$TTL` are prepended before parsing.
- `notify_timeout_secs` defaulted to 5 in code while every shipped config says 3.
- The log target was attached only at exactly `Debug`, so `trace` printed less
  context than `debug`; two startup notices went to stdout ignoring the level.
- `bindizr.conf.toml` shipped at 0644 with the database URL in it.

## Testing

`cargo test --workspace --all-features -- --test-threads=1` passes: 469 tests,
including the 147 e2e. clippy and `cargo +nightly fmt --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
