### PR TITLE
fix(dns): unblock the UDP listener, gate unsigned nsupdate, and cache ACL lookups

### DIFF
--- a/bindizr.conf.toml
+++ b/bindizr.conf.toml
@@ -30,7 +30,7 @@ zone_cache = true             # Cache each zone's records by serial so repeated 
 notify_on_startup = false     # Send DNS NOTIFY when bindizr starts
 notify_retries = 3            # Retry count after the initial NOTIFY attempt
 notify_timeout_secs = 3       # Timeout in seconds for each NOTIFY send/response wait
-nsupdate_allow_unsigned = false # Accept unsigned nsupdate requests (not recommended in production; TSIG keys/policies are managed via CLI or HTTP API)
+nsupdate_allow_unsigned = false # Accept unsigned nsupdate requests from this host only (TSIG keys/policies are managed via CLI or HTTP API)
 journal_retention_days = 365  # Days of IXFR journal/SOA history to keep (0 = unlimited); bounds rollback depth, pruned serials fall back to AXFR
 
 [logging]

--- a/crates/bindizr/README.md
+++ b/crates/bindizr/README.md
@@ -65,7 +65,7 @@ zone_cache = true             # Cache each zone's records by serial so repeated 
 notify_on_startup = false     # Send DNS NOTIFY when bindizr starts
 notify_retries = 3            # Retry count after the initial NOTIFY attempt
 notify_timeout_secs = 3       # Timeout in seconds for each NOTIFY send/response wait
-nsupdate_allow_unsigned = false # Accept unsigned nsupdate requests (not recommended in production; TSIG keys/grants are managed via CLI or HTTP API)
+nsupdate_allow_unsigned = false # Accept unsigned nsupdate requests from this host only (TSIG keys/grants are managed via CLI or HTTP API)
 journal_retention_days = 365  # Days of IXFR journal/SOA history to keep (0 = unlimited); bounds rollback depth, pruned serials fall back to AXFR
 
 [logging]

--- a/crates/bindizr/src/dns/mod.rs
+++ b/crates/bindizr/src/dns/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod error;
 pub(crate) mod server;
 pub(crate) mod wire;
 
-use std::{future::Future, io::ErrorKind, net::SocketAddr, time::Duration};
+use std::{future::Future, io::ErrorKind, net::SocketAddr, sync::Arc, time::Duration};
 
 use bindizr_core::{
     config,
@@ -15,12 +15,19 @@ use bindizr_core::{
 use server::acl::SecondaryAcl;
 use tokio::{
     net::{TcpListener, TcpStream, UdpSocket},
+    sync::Semaphore,
     time::timeout,
 };
 
 use crate::shutdown::Shutdown;
 
 const TCP_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Datagrams answered at once; past this the listener drops, since a caller retries.
+const MAX_UDP_IN_FLIGHT: usize = 256;
+
+/// Connections served at once; the accept backlog holds the rest.
+const MAX_TCP_CONNECTIONS: usize = 128;
 
 /// Initializes the DNS service: prepares the catalog zone and spawns the TCP and UDP servers.
 pub(crate) async fn initialize(shutdown: &Shutdown) -> Result<(), String> {
@@ -67,9 +74,19 @@ async fn run_tcp_server(
     secondary_acl: SecondaryAcl,
     stop: impl Future<Output = ()>,
 ) -> Result<(), String> {
+    let open = Arc::new(Semaphore::new(MAX_TCP_CONNECTIONS));
     tokio::pin!(stop);
 
     loop {
+        // The slot comes before the accept, so the backlog holds the excess.
+        let permit = tokio::select! {
+            permit = open.clone().acquire_owned() => permit.map_err(|e| e.to_string())?,
+            () = &mut stop => {
+                log_info!("DNS TCP server stopping");
+                return Ok(());
+            }
+        };
+
         let accepted = tokio::select! {
             accepted = listener.accept() => accepted,
             () = &mut stop => {
@@ -85,6 +102,7 @@ async fn run_tcp_server(
                     if let Err(e) = handle_tcp_connection(stream, client_addr, allowed).await {
                         log_error!("DNS TCP connection error from {}: {}", client_addr, e);
                     }
+                    drop(permit);
                 });
             }
             Err(e) => {
@@ -195,6 +213,8 @@ async fn run_udp_server(
     secondary_acl: SecondaryAcl,
     stop: impl Future<Output = ()>,
 ) -> Result<(), String> {
+    let socket = Arc::new(socket);
+    let in_flight = Arc::new(Semaphore::new(MAX_UDP_IN_FLIGHT));
     let mut buf = vec![0u8; 65535];
     tokio::pin!(stop);
 
@@ -215,61 +235,82 @@ async fn run_udp_server(
             }
         };
 
-        let query_data = &buf[..len];
-
-        if message::is_response(query_data) {
-            log_warn!("Ignoring a DNS UDP response from {}", client_addr);
+        let Ok(permit) = in_flight.clone().try_acquire_owned() else {
+            log_warn!(
+                "Dropping DNS UDP query from {}: {} already in flight",
+                client_addr,
+                MAX_UDP_IN_FLIGHT
+            );
             continue;
-        }
-
-        if server::nsupdate::is_nsupdate(query_data) {
-            if let Err(e) =
-                server::nsupdate::handle_udp_nsupdate(&socket, query_data, client_addr).await
-            {
-                log_error!("NSUPDATE UDP handler failed for {}: {}", client_addr, e);
-            }
-            continue;
-        }
-
-        let query = match message::ParsedQuery::parse(query_data) {
-            Ok(query) => query,
-            Err(_) => continue,
         };
 
-        if query.opcode != Opcode::QUERY {
-            log_info!(
-                "Refusing DNS UDP opcode {:?} from {}",
-                query.opcode,
-                client_addr
-            );
-            let response = query.error_response(Rcode::NOTIMP);
-            if let Err(e) = socket.send_to(&response, client_addr).await {
-                log_warn!("Failed to answer DNS UDP query from {}: {}", client_addr, e);
-            }
-            continue;
-        }
+        let query_data = buf[..len].to_vec();
+        let socket = socket.clone();
+        let secondary_acl = secondary_acl.clone();
+        tokio::spawn(async move {
+            dispatch_udp_query(&socket, client_addr, &secondary_acl, &query_data).await;
+            drop(permit);
+        });
+    }
+}
 
-        if query.qtype == Rtype::SOA {
-            if let Err(e) =
-                server::soa::handle_udp_soa(&socket, client_addr, &secondary_acl, &query).await
-            {
-                log_warn!("Failed to handle SOA UDP query from {}: {}", client_addr, e);
-            }
-        } else {
-            let response = if server::is_xfr_query_type(query.qtype) {
-                server::handle_udp_query(client_addr, &secondary_acl, &query).await
-            } else {
-                log_info!(
-                    "Refusing out-of-scope DNS UDP query from {} (qtype={:?})",
-                    client_addr,
-                    query.qtype
-                );
-                query.error_response(Rcode::REFUSED)
-            };
+async fn dispatch_udp_query(
+    socket: &UdpSocket,
+    client_addr: SocketAddr,
+    secondary_acl: &SecondaryAcl,
+    query_data: &[u8],
+) {
+    if message::is_response(query_data) {
+        log_warn!("Ignoring a DNS UDP response from {}", client_addr);
+        return;
+    }
 
-            if let Err(e) = socket.send_to(&response, client_addr).await {
-                log_warn!("Failed to answer DNS UDP query from {}: {}", client_addr, e);
-            }
+    if server::nsupdate::is_nsupdate(query_data) {
+        if let Err(e) = server::nsupdate::handle_udp_nsupdate(socket, query_data, client_addr).await
+        {
+            log_error!("NSUPDATE UDP handler failed for {}: {}", client_addr, e);
         }
+        return;
+    }
+
+    let Ok(query) = message::ParsedQuery::parse(query_data) else {
+        return;
+    };
+
+    if query.opcode != Opcode::QUERY {
+        log_info!(
+            "Refusing DNS UDP opcode {:?} from {}",
+            query.opcode,
+            client_addr
+        );
+        send_udp_response(socket, client_addr, &query.error_response(Rcode::NOTIMP)).await;
+        return;
+    }
+
+    if query.qtype == Rtype::SOA {
+        if let Err(e) =
+            server::soa::handle_udp_soa(socket, client_addr, secondary_acl, &query).await
+        {
+            log_warn!("Failed to handle SOA UDP query from {}: {}", client_addr, e);
+        }
+        return;
+    }
+
+    let response = if server::is_xfr_query_type(query.qtype) {
+        server::handle_udp_query(client_addr, secondary_acl, &query).await
+    } else {
+        log_info!(
+            "Refusing out-of-scope DNS UDP query from {} (qtype={:?})",
+            client_addr,
+            query.qtype
+        );
+        query.error_response(Rcode::REFUSED)
+    };
+    send_udp_response(socket, client_addr, &response).await;
+}
+
+async fn send_udp_response(socket: &UdpSocket, client_addr: SocketAddr, response: &[u8]) {
+    if let Err(e) = socket.send_to(response, client_addr).await {
+        log_warn!("Failed to answer DNS UDP query from {}: {}", client_addr, e);
     }
 }

--- a/crates/bindizr/src/dns/server/acl.rs
+++ b/crates/bindizr/src/dns/server/acl.rs
@@ -13,7 +13,7 @@ use bindizr_core::{
     dns::address::{ParsedAddress, parse_address_target},
     log_warn,
 };
-use tokio::{net::lookup_host, time::timeout};
+use tokio::{net::lookup_host, sync::Mutex as AsyncMutex, time::timeout};
 
 /// How long a resolved hostname is reused; an address changes rarely.
 const RESOLVED_TTL: Duration = Duration::from_secs(60);
@@ -68,6 +68,17 @@ struct CachedAddrs {
 
 static RESOLVED: OnceLock<Mutex<HashMap<String, CachedAddrs>>> = OnceLock::new();
 
+/// Held across a lookup so a cold cache costs one resolver request, not one per
+/// waiting query. Entries are few, so one gate for all of them is enough.
+static RESOLVING: OnceLock<AsyncMutex<()>> = OnceLock::new();
+
+fn cached_addrs(host_port: &str) -> Option<Vec<IpAddr>> {
+    locked_cache()
+        .get(host_port)
+        .filter(|cached| cached.expires_at > Instant::now())
+        .map(|cached| cached.addrs.clone())
+}
+
 fn locked_cache() -> std::sync::MutexGuard<'static, HashMap<String, CachedAddrs>> {
     RESOLVED
         .get_or_init(|| Mutex::new(HashMap::new()))
@@ -97,10 +108,15 @@ pub(crate) async fn is_client_allowed(client_ip: IpAddr, acl: &SecondaryAcl) -> 
 }
 
 async fn resolve_acl_host(host_port: &str) -> Vec<IpAddr> {
-    if let Some(cached) = locked_cache().get(host_port)
-        && cached.expires_at > Instant::now()
-    {
-        return cached.addrs.clone();
+    if let Some(addrs) = cached_addrs(host_port) {
+        return addrs;
+    }
+
+    let _resolving = RESOLVING.get_or_init(|| AsyncMutex::new(())).lock().await;
+
+    // Another waiter may have filled the entry while this one queued.
+    if let Some(addrs) = cached_addrs(host_port) {
+        return addrs;
     }
 
     let (addrs, ttl) = match timeout(RESOLVE_TIMEOUT, lookup_host(host_port)).await {

--- a/crates/bindizr/src/dns/server/acl.rs
+++ b/crates/bindizr/src/dns/server/acl.rs
@@ -1,14 +1,28 @@
 //! Access control for zone transfers: matches client addresses against the
 //! configured secondary servers.
 
-use std::net::IpAddr;
+use std::{
+    collections::HashMap,
+    net::IpAddr,
+    sync::{Mutex, OnceLock},
+    time::{Duration, Instant},
+};
 
 use bindizr_core::{
     config,
     dns::address::{ParsedAddress, parse_address_target},
     log_warn,
 };
-use tokio::net::lookup_host;
+use tokio::{net::lookup_host, time::timeout};
+
+/// How long a resolved hostname is reused; an address changes rarely.
+const RESOLVED_TTL: Duration = Duration::from_secs(60);
+
+/// Failures are remembered too, so a dead resolver costs one lookup per window.
+const RESOLVE_FAILURE_TTL: Duration = Duration::from_secs(5);
+
+/// A resolver that never answers must not hold a DNS request open.
+const RESOLVE_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Clone)]
 pub(crate) struct SecondaryAcl {
@@ -47,25 +61,75 @@ enum SecondaryAclEntry {
     HostPort(String),
 }
 
+struct CachedAddrs {
+    addrs: Vec<IpAddr>,
+    expires_at: Instant,
+}
+
+static RESOLVED: OnceLock<Mutex<HashMap<String, CachedAddrs>>> = OnceLock::new();
+
+fn locked_cache() -> std::sync::MutexGuard<'static, HashMap<String, CachedAddrs>> {
+    RESOLVED
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 pub(crate) async fn is_client_allowed(client_ip: IpAddr, acl: &SecondaryAcl) -> bool {
+    // Literals first: a match there answers without reaching the resolver.
+    if acl
+        .entries
+        .iter()
+        .any(|entry| matches!(entry, SecondaryAclEntry::Ip(ip) if *ip == client_ip))
+    {
+        return true;
+    }
+
     for entry in &acl.entries {
-        match entry {
-            SecondaryAclEntry::Ip(ip) if *ip == client_ip => return true,
-            SecondaryAclEntry::Ip(_) => {}
-            SecondaryAclEntry::HostPort(host_port) => match lookup_host(host_port).await {
-                Ok(addrs) => {
-                    if addrs.into_iter().any(|addr| addr.ip() == client_ip) {
-                        return true;
-                    }
-                }
-                Err(e) => {
-                    log_warn!("Failed to resolve DNS ACL host '{}': {}", host_port, e);
-                }
-            },
+        if let SecondaryAclEntry::HostPort(host_port) = entry
+            && resolve_acl_host(host_port).await.contains(&client_ip)
+        {
+            return true;
         }
     }
 
     false
+}
+
+async fn resolve_acl_host(host_port: &str) -> Vec<IpAddr> {
+    if let Some(cached) = locked_cache().get(host_port)
+        && cached.expires_at > Instant::now()
+    {
+        return cached.addrs.clone();
+    }
+
+    let (addrs, ttl) = match timeout(RESOLVE_TIMEOUT, lookup_host(host_port)).await {
+        Ok(Ok(addrs)) => (
+            addrs.map(|addr| addr.ip()).collect::<Vec<_>>(),
+            RESOLVED_TTL,
+        ),
+        Ok(Err(e)) => {
+            log_warn!("Failed to resolve DNS ACL host '{}': {}", host_port, e);
+            (Vec::new(), RESOLVE_FAILURE_TTL)
+        }
+        Err(_) => {
+            log_warn!(
+                "Timed out resolving DNS ACL host '{}' after {:?}",
+                host_port,
+                RESOLVE_TIMEOUT
+            );
+            (Vec::new(), RESOLVE_FAILURE_TTL)
+        }
+    };
+
+    locked_cache().insert(
+        host_port.to_string(),
+        CachedAddrs {
+            addrs: addrs.clone(),
+            expires_at: Instant::now() + ttl,
+        },
+    );
+    addrs
 }
 
 #[cfg(test)]
@@ -81,6 +145,15 @@ mod tests {
                 SecondaryAclEntry::HostPort("bind9-0.bind9-headless:53".to_string()),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn literal_entries_answer_without_resolving() {
+        // The unresolvable entry proves no lookup happened.
+        let acl = SecondaryAcl::parse("192.0.2.10, no-such-host.invalid:53");
+
+        assert!(is_client_allowed("192.0.2.10".parse().unwrap(), &acl).await);
+        assert!(locked_cache().is_empty());
     }
 
     #[test]

--- a/crates/bindizr/src/dns/server/nsupdate/mod.rs
+++ b/crates/bindizr/src/dns/server/nsupdate/mod.rs
@@ -72,7 +72,7 @@ async fn handle_nsupdate_request(query_data: &[u8], client_addr: SocketAddr) -> 
         .tsig
         .as_ref()
         .map_or(DEFAULT_FUDGE, |tsig| tsig.fudge);
-    let (result, signer) = update::apply_update(parsed, query_data).await;
+    let (result, signer) = update::apply_update(parsed, query_data, client_addr.ip()).await;
 
     let rcode = match result {
         Ok(changed) => {

--- a/crates/bindizr/src/dns/server/nsupdate/update/mod.rs
+++ b/crates/bindizr/src/dns/server/nsupdate/update/mod.rs
@@ -136,7 +136,10 @@ async fn authenticate_request(
         Some(tsig) => tsig,
         None => {
             // An unsigned update carries no identity a remote sender could prove.
-            if config::bindizr_config().dns.nsupdate_allow_unsigned && client_ip.is_loopback() {
+            // A v4 client on a `::` listener arrives mapped, so canonicalize first.
+            if config::bindizr_config().dns.nsupdate_allow_unsigned
+                && client_ip.to_canonical().is_loopback()
+            {
                 return Ok(None);
             }
             return Err(UpdateError::Refused(

--- a/crates/bindizr/src/dns/server/nsupdate/update/mod.rs
+++ b/crates/bindizr/src/dns/server/nsupdate/update/mod.rs
@@ -2,6 +2,8 @@
 //! TSIG verification, the wire shapes RFC 2136 fixes for each section, and
 //! rdata parsing. Everything that touches zone data lives in the service.
 
+use std::net::IpAddr;
+
 use bindizr_core::{
     config,
     dns::{
@@ -78,6 +80,7 @@ impl From<DynamicUpdateError> for UpdateError {
 pub(crate) async fn apply_update(
     request: UpdateRequest,
     query_data: &[u8],
+    client_ip: IpAddr,
 ) -> (Result<bool, UpdateError>, Option<ResponseSigner>) {
     let mut signer = None;
     let result = async {
@@ -95,7 +98,7 @@ pub(crate) async fn apply_update(
 
         // Authenticate before anything zone-specific: keys are zone-independent,
         // and this lets even NOTZONE/REFUSED responses be signed.
-        let key = authenticate_request(&request, query_data, &mut signer).await?;
+        let key = authenticate_request(&request, query_data, client_ip, &mut signer).await?;
 
         let update = DynamicUpdate {
             zone_name: zone_name.to_string(),
@@ -126,12 +129,14 @@ pub(crate) async fn apply_update(
 async fn authenticate_request(
     request: &UpdateRequest,
     query_data: &[u8],
+    client_ip: IpAddr,
     signer: &mut Option<ResponseSigner>,
 ) -> Result<Option<TsigKey>, UpdateError> {
     let tsig = match &request.tsig {
         Some(tsig) => tsig,
         None => {
-            if config::bindizr_config().dns.nsupdate_allow_unsigned {
+            // An unsigned update carries no identity a remote sender could prove.
+            if config::bindizr_config().dns.nsupdate_allow_unsigned && client_ip.is_loopback() {
                 return Ok(None);
             }
             return Err(UpdateError::Refused(

--- a/crates/bindizr/src/dns/server/soa.rs
+++ b/crates/bindizr/src/dns/server/soa.rs
@@ -44,7 +44,9 @@ pub(crate) async fn handle_udp_soa(
 
 /// `bindizr doctor` probes over the wire, reaching a concrete `listen_addr` from it.
 fn is_self_probe(client_ip: IpAddr) -> bool {
-    client_ip.is_loopback() || client_ip == config::bindizr_config().dns.listen_addr
+    // A v4 client on a `::` listener arrives mapped, so canonicalize first.
+    let client_ip = client_ip.to_canonical();
+    client_ip.is_loopback() || client_ip == config::bindizr_config().dns.listen_addr.to_canonical()
 }
 
 /// The response bytes, which TCP and UDP send alike.

--- a/docs/cli/nsupdate.md
+++ b/docs/cli/nsupdate.md
@@ -50,9 +50,10 @@ EOF
 A zone no key has been granted refuses nsupdate, except from global keys,
 which may update any zone.
 
-!!! warning "`nsupdate_allow_unsigned` is a production footgun"
+!!! warning "`nsupdate_allow_unsigned` covers local testing only"
 
     Setting `dns.nsupdate_allow_unsigned = true` accepts unsigned requests for
-    every zone, regardless of grants. Signed requests are always verified,
-    but anyone who can reach the DNS port can write unsigned. Leave it off
-    outside of local testing.
+    every zone, regardless of grants, but only from the host bindizr runs on.
+    An unsigned update carries no identity a remote sender could prove, so a
+    request from anywhere else is refused whatever the setting says. Signed
+    requests are always verified.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ zone_cache = true             # Cache each zone's records by serial so repeated 
 notify_on_startup = false     # Send DNS NOTIFY when bindizr starts
 notify_retries = 3            # Retry count after the initial NOTIFY attempt
 notify_timeout_secs = 3       # Timeout in seconds for each NOTIFY send/response wait
-nsupdate_allow_unsigned = false # Accept unsigned nsupdate requests (not recommended in production; TSIG keys/grants are managed via CLI or HTTP API)
+nsupdate_allow_unsigned = false # Accept unsigned nsupdate requests from this host only (TSIG keys/grants are managed via CLI or HTTP API)
 journal_retention_days = 365  # Days of IXFR journal/SOA history to keep (0 = unlimited); bounds rollback depth, pruned serials fall back to AXFR
 
 [logging]


### PR DESCRIPTION
Three defects on the DNS request path, each verified against a running daemon.
They compound: a slow resolver held a request open, that request blocked the
whole UDP listener, and meanwhile an unsigned update could arrive from anywhere.

## The UDP listener served one query at a time

Every datagram was handled inline, so the receive loop could not read the next
packet until the current one finished. A catalog SOA query lists every zone and
opens a write transaction, so it is not quick.

With 20k zones, twelve catalog SOA queries in flight pushed a following light
query from **13ms to 2,346ms**. It was not waiting on its own work; it was
waiting to be read off the socket.

Each datagram now gets its own task. Both listeners are bounded, which they were
not before: UDP drops past the cap because a caller retries and a queued reply
arrives after it gave up, while TCP takes its slot before the accept so the
excess waits in the kernel backlog instead of piling up as tasks.

## Unsigned nsupdate had no address restriction

`dns.nsupdate_allow_unsigned = true` accepted zone rewrites from anyone who
could reach the DNS port, grants ignored. The documentation already scoped the
flag to local testing; the code now holds that contract, because an unsigned
update carries no identity a remote sender could prove. Remote callers have
TSIG, and that path is untouched.

Verified against a running daemon: unsigned from loopback applies, unsigned from
a LAN address is REFUSED, and a TSIG-signed update from that same LAN address
still applies.

## ACL hostnames were resolved on every request

`is_client_allowed` called the resolver for each hostname entry on every query,
with no cache and no timeout, and got there even when a later literal entry
already matched.

Literals are checked first now, so an IP-listed secondary never reaches the
resolver. Answers are held for a window, failures briefly too so a dead resolver
costs one lookup per window rather than one per request, and a lookup that never
returns no longer holds the request open.

On macOS this shows no measured difference, because mDNSResponder already
caches. The release binary links `x86_64-unknown-linux-musl`, whose
`getaddrinfo` does not, and the Helm chart names secondaries by host, so each
query was a real round trip on the deployment targets.

## Testing

`cargo test --workspace --all-features -- --test-threads=1` passes: 471 tests,
including the 147 e2e. clippy and `cargo +nightly fmt --check` are clean.

Two things were **not** demonstrated. The concurrency caps were verified by
construction rather than under load: the probe harness serialised hundreds of
socket reads and timed out twice. And a hung resolver could not be simulated
here, so the lookup timeout is unexercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
